### PR TITLE
fix: issue with loadedEntityList on custom server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ run
 *.skb
 
 *.jar
+*.log
 
 TrackAPI

--- a/src/main/java/cam72cam/mod/entity/ModdedEntity.java
+++ b/src/main/java/cam72cam/mod/entity/ModdedEntity.java
@@ -372,11 +372,7 @@ public class ModdedEntity extends Entity implements IEntityAdditionalSpawnData {
                 passengerPositions.put(passenger.getUUID(), offset);
             }
 
-            System.out.println("Seat: " + seat);
-            System.out.println("Passenger: " + passenger);
-            System.out.println("Offset before: " + offset);
             offset = iRidable.onPassengerUpdate(passenger, offset);
-            System.out.println("Offset: " + offset);
             if (!seat.isPassenger(passenger.internal))
                 return;
 

--- a/src/main/java/cam72cam/mod/entity/ModdedEntity.java
+++ b/src/main/java/cam72cam/mod/entity/ModdedEntity.java
@@ -392,6 +392,10 @@ public class ModdedEntity extends Entity implements IEntityAdditionalSpawnData {
             passenger.internal.rotationYaw = passenger.internal.rotationYaw + delta;
 
             seat.shouldSit = iRidable.shouldRiderSit(passenger);
+
+            if (self.getWorld().isServer) {
+                new PassengerPositionsPacket(this).sendToObserving(self);
+            }
         }
     }
 

--- a/src/main/java/cam72cam/mod/entity/SeatEntity.java
+++ b/src/main/java/cam72cam/mod/entity/SeatEntity.java
@@ -1,5 +1,7 @@
 package cam72cam.mod.entity;
 
+import java.util.UUID;
+
 import cam72cam.mod.ModCore;
 import cam72cam.mod.serialization.TagCompound;
 import cam72cam.mod.world.World;
@@ -12,8 +14,6 @@ import net.minecraftforge.fml.common.registry.IEntityAdditionalSpawnData;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import java.util.UUID;
-
 /** Seat construct to make multiple riders actually work */
 public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
     static final ResourceLocation ID = new ResourceLocation(ModCore.MODID, "seat");
@@ -21,7 +21,8 @@ public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
     private UUID parent;
     // What is in the seat
     private UUID passenger;
-    // If we should try to render the rider as standing or sitting (partial support!)
+    // If we should try to render the rider as standing or sitting (partial
+    // support!)
     boolean shouldSit = true;
     // If a passenger has mounted and then dismounted (if so, we can go away)
     private boolean hasHadPassenger = false;
@@ -29,7 +30,7 @@ public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
     private int ticks = 0;
 
     /** MC reflection */
-    public SeatEntity(net.minecraft.world.World worldIn) {
+    public SeatEntity(final net.minecraft.world.World worldIn) {
         super(worldIn);
     }
 
@@ -39,7 +40,7 @@ public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
     }
 
     @Override
-    protected void readEntityFromNBT(NBTTagCompound compound) {
+    protected void readEntityFromNBT(final NBTTagCompound compound) {
         TagCompound data = new TagCompound(compound);
         parent = data.getUUID("parent");
         passenger = data.getUUID("passenger");
@@ -47,7 +48,7 @@ public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
     }
 
     @Override
-    protected void writeEntityToNBT(NBTTagCompound compound) {
+    protected void writeEntityToNBT(final NBTTagCompound compound) {
         TagCompound data = new TagCompound(compound);
         data.setUUID("parent", parent);
         data.setUUID("passenger", passenger);
@@ -56,10 +57,9 @@ public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
 
     @Override
     public void onUpdate() {
-        ticks ++;
-        if (world.isRemote || ticks < 5) {
+        ticks++;
+        if (world.isRemote || ticks < 5)
             return;
-        }
 
         if (parent == null) {
             ModCore.debug("No parent, goodbye");
@@ -75,7 +75,8 @@ public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
         if (getPassengers().isEmpty()) {
             if (this.ticks < 20) {
                 if (!hasHadPassenger) {
-                    cam72cam.mod.entity.Entity toRide = World.get(world).getEntity(passenger, cam72cam.mod.entity.Entity.class);
+                    cam72cam.mod.entity.Entity toRide =
+                            World.get(world).getEntity(passenger, cam72cam.mod.entity.Entity.class);
                     if (toRide != null) {
                         ModCore.debug("FORCE RIDER");
                         toRide.internal.startRiding(this, true);
@@ -97,21 +98,21 @@ public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
         }
     }
 
-    public void setup(ModdedEntity moddedEntity, Entity passenger) {
+    public void setup(final ModdedEntity moddedEntity, final Entity passenger) {
         this.parent = moddedEntity.getUniqueID();
         this.setPosition(moddedEntity.posX, moddedEntity.posY, moddedEntity.posZ);
         this.passenger = passenger.getUniqueID();
     }
 
-    public void moveTo(ModdedEntity moddedEntity) {
+    public void moveTo(final ModdedEntity moddedEntity) {
         this.parent = moddedEntity.getUniqueID();
     }
 
     public cam72cam.mod.entity.Entity getParent() {
-        cam72cam.mod.entity.Entity linked = World.get(world).getEntity(parent, cam72cam.mod.entity.Entity.class);
-        if (linked != null && linked.internal instanceof ModdedEntity) {
+        cam72cam.mod.entity.Entity linked =
+                World.get(world).getEntity(parent, cam72cam.mod.entity.Entity.class);
+        if (linked != null && linked.internal instanceof ModdedEntity)
             return linked;
-        }
         return null;
     }
 
@@ -121,8 +122,9 @@ public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
     }
 
     @Override
-    public final void updatePassenger(net.minecraft.entity.Entity passenger) {
-        cam72cam.mod.entity.Entity linked = World.get(world).getEntity(parent, cam72cam.mod.entity.Entity.class);
+    public final void updatePassenger(final net.minecraft.entity.Entity passenger) {
+        cam72cam.mod.entity.Entity linked =
+                World.get(world).getEntity(parent, cam72cam.mod.entity.Entity.class);
         if (linked != null && linked.internal instanceof ModdedEntity) {
             ((ModdedEntity) linked.internal).updateSeat(this);
         }
@@ -134,8 +136,9 @@ public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
     }
 
     @Override
-    public final void removePassenger(net.minecraft.entity.Entity passenger) {
-        cam72cam.mod.entity.Entity linked = World.get(world).getEntity(parent, cam72cam.mod.entity.Entity.class);
+    public final void removePassenger(final net.minecraft.entity.Entity passenger) {
+        cam72cam.mod.entity.Entity linked =
+                World.get(world).getEntity(parent, cam72cam.mod.entity.Entity.class);
         if (linked != null && linked.internal instanceof ModdedEntity) {
             ((ModdedEntity) linked.internal).removeSeat(this);
         }
@@ -143,17 +146,16 @@ public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
     }
 
     public cam72cam.mod.entity.Entity getEntityPassenger() {
-        if (this.isDead) {
+        if (this.isDead)
             return null;
-        }
-        if (this.getPassengers().size() == 0) {
+        if (this.getPassengers().size() == 0)
             return null;
-        }
+        getPassengers().forEach(p -> System.out.println("Passengers: " + p));
         return World.get(world).getEntity(getPassengers().get(0));
     }
 
     @Override
-    public void writeSpawnData(ByteBuf buffer) {
+    public void writeSpawnData(final ByteBuf buffer) {
         TagCompound data = new TagCompound();
         data.setUUID("parent", parent);
         data.setUUID("passenger", passenger);
@@ -161,7 +163,7 @@ public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
     }
 
     @Override
-    public void readSpawnData(ByteBuf additionalData) {
+    public void readSpawnData(final ByteBuf additionalData) {
         TagCompound data = new TagCompound(ByteBufUtils.readTag(additionalData));
         parent = data.getUUID("parent");
         passenger = data.getUUID("passenger");
@@ -169,7 +171,7 @@ public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
 
     @Override
     @SideOnly(Side.CLIENT)
-    public boolean isInRangeToRenderDist(double distance) {
+    public boolean isInRangeToRenderDist(final double distance) {
         return false;
     }
 }

--- a/src/main/java/cam72cam/mod/entity/SeatEntity.java
+++ b/src/main/java/cam72cam/mod/entity/SeatEntity.java
@@ -150,7 +150,6 @@ public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
             return null;
         if (this.getPassengers().size() == 0)
             return null;
-        getPassengers().forEach(p -> System.out.println("Passengers: " + p));
         return World.get(world).getEntity(getPassengers().get(0));
     }
 

--- a/src/main/java/cam72cam/mod/gui/container/ClientContainerBuilder.java
+++ b/src/main/java/cam72cam/mod/gui/container/ClientContainerBuilder.java
@@ -244,4 +244,9 @@ public class ClientContainerBuilder extends GuiContainer implements IContainerBu
         super.drawScreen(mouseX, mouseY, partialTicks);
         this.renderHoveredToolTip(mouseX, mouseY);
     }
+
+    @Override
+    public void drawImage(Identifier tex, int x, int y, int width, int height, float alpha) {
+        GUIHelpers.texturedRect(tex, x, y, width, height, alpha); 
+    }
 }

--- a/src/main/java/cam72cam/mod/gui/container/IContainerBuilder.java
+++ b/src/main/java/cam72cam/mod/gui/container/IContainerBuilder.java
@@ -3,8 +3,12 @@ package cam72cam.mod.gui.container;
 import cam72cam.mod.fluid.Fluid;
 import cam72cam.mod.item.ItemStack;
 import cam72cam.mod.item.ItemStackHandler;
+import cam72cam.mod.resource.Identifier;
 
-/** Provides a way to spec out a container piece by piece that functions both server and client side for slot synchronization */
+/**
+ * Provides a way to spec out a container piece by piece that functions both
+ * server and client side for slot synchronization
+ */
 public interface IContainerBuilder {
     /** Draw the top bar of a container window */
     int drawTopBar(int x, int y, int slots);
@@ -21,7 +25,10 @@ public interface IContainerBuilder {
     /** Draw the bottom bar of the player inv */
     int drawPlayerInventory(int currY, int horizSlots);
 
-    /** Draw a connector for when the player inv width == container width (TODO internal only?) */
+    /**
+     * Draw a connector for when the player inv width == container width (TODO
+     * internal only?)
+     */
     int drawPlayerMidBar(int x, int y);
 
     /** Draw a transparent version of this stack at these coords */
@@ -44,4 +51,7 @@ public interface IContainerBuilder {
 
     /** Draw a centered and shadowed string at coords */
     void drawCenteredString(String quantityStr, int x, int y);
+
+    /** Draw a custom image */
+    void drawImage(Identifier tex, int x, int y, int width, int height, float alpha);
 }

--- a/src/main/java/cam72cam/mod/gui/container/ServerContainerBuilder.java
+++ b/src/main/java/cam72cam/mod/gui/container/ServerContainerBuilder.java
@@ -4,6 +4,7 @@ import cam72cam.mod.fluid.Fluid;
 import cam72cam.mod.item.ItemStack;
 import cam72cam.mod.item.ItemStackHandler;
 import cam72cam.mod.render.opengl.RenderState;
+import cam72cam.mod.resource.Identifier;
 import invtweaks.api.container.ChestContainer;
 import invtweaks.api.container.ContainerSection;
 import invtweaks.api.container.ContainerSectionCallback;
@@ -215,5 +216,10 @@ public class ServerContainerBuilder extends net.minecraft.inventory.Container im
         }
 
         return itemstack;
+    }
+
+    @Override
+    public void drawImage(Identifier tex, int x, int y, int width, int height, float alpha) {
+        this.ySize = Math.max(ySize, y + height);
     }
 }

--- a/src/main/java/cam72cam/mod/gui/helpers/GUIHelpers.java
+++ b/src/main/java/cam72cam/mod/gui/helpers/GUIHelpers.java
@@ -37,9 +37,11 @@ public class GUIHelpers {
     }
 
     /** Draw a full image (tex) at coords with given width/height */
-    public static void texturedRect(Identifier tex, int x, int y, int width, int height) {
+    public static void texturedRect(Identifier tex, int x, int y, int width, int height, float alpha) {
         try (With ctx = RenderContext.apply(
-                new RenderState().texture(Texture.wrap(tex))
+                new RenderState().texture(Texture.wrap(tex)).color(1, 1, 1, alpha).alpha_test(true)
+                .blend(new BlendMode(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA))
+                .depth_test(false)
         )) {
             Gui.drawScaledCustomSizeModalRect(x, y, 0, 0, 1, 1, width, height, 1, 1);
         }

--- a/src/main/java/cam72cam/mod/gui/screen/IScreenBuilder.java
+++ b/src/main/java/cam72cam/mod/gui/screen/IScreenBuilder.java
@@ -18,9 +18,9 @@ public interface IScreenBuilder {
 
     /**
      * Add an image to the GUI
-     * @see cam72cam.mod.gui.helpers.GUIHelpers#texturedRect(Identifier, int, int, int, int)
+     * @see cam72cam.mod.gui.helpers.GUIHelpers#texturedRect(Identifier, int, int, int, int, alpha)
      */
-    void drawImage(Identifier tex, int x, int y, int width, int height);
+    void drawImage(Identifier tex, int x, int y, int width, int height, float alpha);
 
     /**
      * Add a tank to the GUI

--- a/src/main/java/cam72cam/mod/gui/screen/ScreenBuilder.java
+++ b/src/main/java/cam72cam/mod/gui/screen/ScreenBuilder.java
@@ -63,8 +63,8 @@ public class ScreenBuilder extends GuiScreen implements IScreenBuilder {
     }
 
     @Override
-    public void drawImage(Identifier tex, int x, int y, int width, int height) {
-        GUIHelpers.texturedRect(tex, this.width / 2 + x, this.height / 4 + y, width, height);
+    public void drawImage(Identifier tex, int x, int y, int width, int height, float alpha) {
+        GUIHelpers.texturedRect(tex, this.width / 2 + x, this.height / 4 + y, width, height, alpha);
     }
 
     @Override

--- a/src/main/java/cam72cam/mod/world/World.java
+++ b/src/main/java/cam72cam/mod/world/World.java
@@ -23,6 +23,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumFacing;
@@ -113,6 +114,12 @@ public class World {
             for (net.minecraft.entity.Entity entity : this.internal.loadedEntityList) {
                 if (!this.entityByID.containsKey(entity.getEntityId())) {
                     ModCore.warn("Adding entity that was not wrapped correctly %s - %s", entity.getUniqueID(), entity);
+                    if (entity instanceof EntityPlayerMP && !this.internal.playerEntities.contains(entity)) {
+                        // if player is no longer online then remove player from loadedEntityList
+                        this.internal.loadedEntityList.remove(entity);
+                        ModCore.warn("Removing entity with uuid %s from loadedEntityList", entity.getUniqueID());
+                        return;
+                    }
                     this.onEntityAdded(entity);
                 }
             }

--- a/src/main/java/cam72cam/mod/world/World.java
+++ b/src/main/java/cam72cam/mod/world/World.java
@@ -1,12 +1,24 @@
 package cam72cam.mod.world;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import cam72cam.mod.MinecraftClient;
 import cam72cam.mod.ModCore;
 import cam72cam.mod.block.BlockEntity;
 import cam72cam.mod.block.BlockType;
 import cam72cam.mod.block.IBlockTypeBlock;
 import cam72cam.mod.block.tile.TileEntity;
-import cam72cam.mod.entity.*;
+import cam72cam.mod.entity.Entity;
+import cam72cam.mod.entity.Living;
+import cam72cam.mod.entity.ModdedEntity;
+import cam72cam.mod.entity.Player;
 import cam72cam.mod.entity.boundingbox.BoundingBox;
 import cam72cam.mod.entity.boundingbox.IBoundingBox;
 import cam72cam.mod.event.ClientEvents;
@@ -16,8 +28,8 @@ import cam72cam.mod.item.IInventory;
 import cam72cam.mod.item.ItemStack;
 import cam72cam.mod.math.Vec3d;
 import cam72cam.mod.math.Vec3i;
-import cam72cam.mod.util.Facing;
 import cam72cam.mod.serialization.TagCompound;
+import cam72cam.mod.util.Facing;
 import net.minecraft.block.*;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLiving;
@@ -25,11 +37,9 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
-import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.math.AxisAlignedBB;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.IPlantable;
@@ -38,11 +48,6 @@ import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
-
-import java.util.*;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /** Wraps both ClientWorld and ServerWorld */
 public class World {
@@ -65,23 +70,24 @@ public class World {
 
     /* World Initialization */
 
-    private World(net.minecraft.world.World world) {
+    private World(final net.minecraft.world.World world) {
         internal = world;
         isClient = world.isRemote;
         isServer = !world.isRemote;
     }
 
     /** Helper function to get a world map (client or server) */
-    private static Map<Integer, World> getWorldMap(net.minecraft.world.World world) {
+    private static Map<Integer, World> getWorldMap(final net.minecraft.world.World world) {
         return world.isRemote ? clientWorlds : serverWorlds;
     }
+
     /** Helper function to get a world in it's respective map */
-    private static World getWorld(net.minecraft.world.World world){
+    private static World getWorld(final net.minecraft.world.World world) {
         return getWorldMap(world).get(world.provider.getDimension());
     }
 
     /** Load world hander, sets up maps and internal handlers */
-    private static void loadWorld(net.minecraft.world.World world) {
+    private static void loadWorld(final net.minecraft.world.World world) {
         if (getWorld(world) == null) {
             World worldWrap = new World(world);
             getWorldMap(world).put(worldWrap.getId(), worldWrap);
@@ -93,7 +99,8 @@ public class World {
     public static void registerEvents() {
         CommonEvents.World.LOAD.subscribe(World::loadWorld);
 
-        CommonEvents.World.UNLOAD.subscribe(world -> getWorldMap(world).remove(world.provider.getDimension()));
+        CommonEvents.World.UNLOAD
+                .subscribe(world -> getWorldMap(world).remove(world.provider.getDimension()));
 
         CommonEvents.World.TICK.subscribe(world -> onTicks.forEach(fn -> fn.accept(get(world))));
 
@@ -113,11 +120,14 @@ public class World {
         if (this.getTicks() % 20 == 0) {
             for (net.minecraft.entity.Entity entity : this.internal.loadedEntityList) {
                 if (!this.entityByID.containsKey(entity.getEntityId())) {
-                    ModCore.warn("Adding entity that was not wrapped correctly %s - %s", entity.getUniqueID(), entity);
-                    if (entity instanceof EntityPlayerMP && !this.internal.playerEntities.contains(entity)) {
+                    ModCore.warn("Adding entity that was not wrapped correctly %s - %s",
+                            entity.getUniqueID(), entity);
+                    if (entity instanceof EntityPlayerMP
+                            && !this.internal.playerEntities.contains(entity)) {
                         // if player is no longer online then remove player from loadedEntityList
                         this.internal.loadedEntityList.remove(entity);
-                        ModCore.warn("Removing entity with uuid %s from loadedEntityList", entity.getUniqueID());
+                        ModCore.warn("Removing entity with uuid %s from loadedEntityList",
+                                entity.getUniqueID());
                         return;
                     }
                     this.onEntityAdded(entity);
@@ -126,8 +136,10 @@ public class World {
             for (int entityId : new ArrayList<>(this.entityByID.keySet())) {
                 if (this.internal.getEntityByID(entityId) == null) {
                     Entity entity = this.entityByID.get(entityId);
-                    if (entity != null && !this.internal.loadedEntityList.contains(entity.internal)) {
-                        ModCore.warn("Dropping entity that was not removed correctly %s - %s", entity.getUUID(), entity);
+                    if (entity != null
+                            && !this.internal.loadedEntityList.contains(entity.internal)) {
+                        ModCore.warn("Dropping entity that was not removed correctly %s - %s",
+                                entity.getUUID(), entity);
                         this.onEntityRemoved(entity.internal);
                     }
                 }
@@ -136,10 +148,9 @@ public class World {
     }
 
     /** Turn a MC world into a UMC world */
-    public static World get(net.minecraft.world.World world) {
-        if (world == null) {
+    public static World get(final net.minecraft.world.World world) {
+        if (world == null)
             return null;
-        }
         if (getWorld(world) == null) {
             // WTF forge
             // I should NOT need to do this
@@ -149,13 +160,16 @@ public class World {
         return getWorld(world);
     }
 
-    /** Based on dim/isRemote get the corresponding UMC world.  Not recommended for general use. */
-    public static World get(int dimID, boolean isClient) {
+    /**
+     * Based on dim/isRemote get the corresponding UMC world. Not recommended for
+     * general use.
+     */
+    public static World get(final int dimID, final boolean isClient) {
         return (isClient ? clientWorlds : serverWorlds).get(dimID);
     }
 
     /** Add tick handler */
-    public static void onTick(Consumer<World> fn) {
+    public static void onTick(final Consumer<World> fn) {
         onTicks.add(fn);
     }
 
@@ -167,14 +181,13 @@ public class World {
     /* Event Methods */
 
     /**
-     * Handle tracking entities that have been added to the internal world.
-     * Wiring from WorldEventListener
+     * Handle tracking entities that have been added to the internal world. Wiring
+     * from WorldEventListener
      */
-    void onEntityAdded(net.minecraft.entity.Entity entityIn) {
-        if (entityByID.containsKey(entityIn.getEntityId())) {
+    void onEntityAdded(final net.minecraft.entity.Entity entityIn) {
+        if (entityByID.containsKey(entityIn.getEntityId()))
             // Dupe
             return;
-        }
 
         Entity entity;
         if (entityIn instanceof ModdedEntity) {
@@ -196,8 +209,8 @@ public class World {
      * Handle tracking entities that have been removed from the internal world.
      * Wiring from WorldEventListener
      */
-    void onEntityRemoved(net.minecraft.entity.Entity entity) {
-        if(entity == null) {
+    void onEntityRemoved(final net.minecraft.entity.Entity entity) {
+        if (entity == null) {
             ModCore.warn("Somehow removed a null entity?");
             return;
         }
@@ -211,43 +224,43 @@ public class World {
     /* Entity Methods */
 
     /** Find a UMC entity by MC entity */
-    public Entity getEntity(net.minecraft.entity.Entity entity) {
+    public Entity getEntity(final net.minecraft.entity.Entity entity) {
         return getEntity(entity.getUniqueID(), Entity.class);
     }
 
     /** Find a UMC entity by MC ID and Entity class */
-    public <T extends Entity> T getEntity(int id, Class<T> type) {
+    public <T extends Entity> T getEntity(final int id, final Class<T> type) {
         Entity ent = entityByID.get(id);
-        if (ent == null) {
+        if (ent == null)
             return null;
-        }
         if (!type.isInstance(ent)) {
-            ModCore.warn("When looking for entity %s by id %s, we instead got a %s", type, id, ent.getClass());
+            ModCore.warn("When looking for entity %s by id %s, we instead got a %s", type, id,
+                    ent.getClass());
             return null;
         }
         return (T) ent;
     }
 
     /** Find UMC entity by MC Entity, assuming type */
-    public <T extends Entity> T getEntity(UUID id, Class<T> type) {
+    public <T extends Entity> T getEntity(final UUID id, final Class<T> type) {
         Entity ent = entityByUUID.get(id);
-        if (ent == null) {
+        if (ent == null)
             return null;
-        }
         if (!type.isInstance(ent)) {
-            ModCore.warn("When looking for entity %s by id %s, we instead got a %s", type, id, ent.getClass());
+            ModCore.warn("When looking for entity %s by id %s, we instead got a %s", type, id,
+                    ent.getClass());
             return null;
         }
         return (T) ent;
     }
 
     /** Find UMC entities by type */
-    public <T extends Entity> List<T> getEntities(Class<T> type) {
-        return getEntities((T val) -> true, type);
+    public <T extends Entity> List<T> getEntities(final Class<T> type) {
+        return getEntities((final T val) -> true, type);
     }
 
     /** Find UMC Entities which match the filter and are of the given type */
-    public <T extends Entity> List<T> getEntities(Predicate<T> filter, Class<T> type) {
+    public <T extends Entity> List<T> getEntities(final Predicate<T> filter, final Class<T> type) {
         List<T> list = new ArrayList<>();
         for (Class<?> key : entitiesByClass.keySet()) {
             if (type.isAssignableFrom(key)) {
@@ -265,61 +278,61 @@ public class World {
     }
 
     /** Add a constructed entity to the world */
-    public boolean spawnEntity(Entity ent) {
+    public boolean spawnEntity(final Entity ent) {
         return internal.spawnEntity(ent.internal);
     }
 
     /** Kill an entity */
-    public void removeEntity(Entity entity) {
+    public void removeEntity(final Entity entity) {
         internal.removeEntity(entity.internal);
     }
 
     /** Force a chunk for up to 5s */
-    public void keepLoaded(Vec3i pos) {
+    public void keepLoaded(final Vec3i pos) {
         ChunkManager.flagEntityPos(this, pos);
     }
 
     /** Internal, do not use */
-    public <T extends net.minecraft.tileentity.TileEntity> T getTileEntity(Vec3i pos, Class<T> cls) {
+    public <T extends net.minecraft.tileentity.TileEntity> T getTileEntity(final Vec3i pos,
+            final Class<T> cls) {
         return getTileEntity(pos, cls, true);
     }
 
     /** Internal, do not use */
-    public <T extends net.minecraft.tileentity.TileEntity> T getTileEntity(Vec3i pos, Class<T> cls, boolean create) {
-        net.minecraft.tileentity.TileEntity ent = internal.getChunk(pos.internal()).getTileEntity(pos.internal(), create ? Chunk.EnumCreateEntityType.IMMEDIATE : Chunk.EnumCreateEntityType.CHECK);
-        if (cls.isInstance(ent)) {
+    public <T extends net.minecraft.tileentity.TileEntity> T getTileEntity(final Vec3i pos,
+            final Class<T> cls, final boolean create) {
+        net.minecraft.tileentity.TileEntity ent = internal.getChunk(pos.internal()).getTileEntity(
+                pos.internal(),
+                create ? Chunk.EnumCreateEntityType.IMMEDIATE : Chunk.EnumCreateEntityType.CHECK);
+        if (cls.isInstance(ent))
             return (T) ent;
-        }
         return null;
     }
 
     /** Get all block entities of the given type */
-    public <T extends BlockEntity> List<T> getBlockEntities(Class<T> cls) {
+    public <T extends BlockEntity> List<T> getBlockEntities(final Class<T> cls) {
         return internal.loadedTileEntityList.stream()
-                .filter(x -> x instanceof TileEntity && ((TileEntity) x).isLoaded() && cls.isInstance(((TileEntity) x).instance()))
-                .map(x -> (T) ((TileEntity) x).instance())
-                .collect(Collectors.toList());
+                .filter(x -> x instanceof TileEntity && ((TileEntity) x).isLoaded()
+                        && cls.isInstance(((TileEntity) x).instance()))
+                .map(x -> (T) ((TileEntity) x).instance()).collect(Collectors.toList());
     }
 
     /** Get a block entity at the position, assuming type */
-    public <T extends BlockEntity> T getBlockEntity(Vec3i pos, Class<T> cls) {
+    public <T extends BlockEntity> T getBlockEntity(final Vec3i pos, final Class<T> cls) {
         TileEntity te = getTileEntity(pos, TileEntity.class);
-        if (te == null) {
+        if (te == null)
             return null;
-        }
         BlockEntity instance = te.instance();
-        if (cls.isInstance(instance)) {
+        if (cls.isInstance(instance))
             return (T) instance;
-        }
         return null;
     }
 
     /** Does this block have a block entity of the given type? */
-    public <T extends BlockEntity> boolean hasBlockEntity(Vec3i pos, Class<T> cls) {
+    public <T extends BlockEntity> boolean hasBlockEntity(final Vec3i pos, final Class<T> cls) {
         TileEntity te = getTileEntity(pos, TileEntity.class);
-        if (te == null) {
+        if (te == null)
             return false;
-        }
         return cls.isInstance(te.instance());
     }
 
@@ -328,7 +341,7 @@ public class World {
      *
      * @see BlockEntity#getData
      */
-    public BlockEntity reconstituteBlockEntity(TagCompound data) {
+    public BlockEntity reconstituteBlockEntity(final TagCompound data) {
         TileEntity te = (TileEntity) TileEntity.create(internal, data.internal);
         if (te == null) {
             ModCore.warn("BAD TE DATA " + data);
@@ -341,14 +354,14 @@ public class World {
     }
 
     /** Set the block entity at pos to given entity */
-    public void setBlockEntity(Vec3i pos, BlockEntity entity) {
+    public void setBlockEntity(final Vec3i pos, final BlockEntity entity) {
         internal.setTileEntity(pos.internal(), entity != null ? entity.internal : null);
         if (entity != null) {
             entity.markDirty();
         }
     }
 
-    /** World time in ticks (Day/Night cycle time)*/
+    /** World time in ticks (Day/Night cycle time) */
     public long getTime() {
         return internal.getWorldTime();
     }
@@ -360,9 +373,8 @@ public class World {
 
     /** Ticks per second (with up to N samples) */
     public double getTPS(int sampleSize) {
-        if (internal.getMinecraftServer() == null) {
+        if (internal.getMinecraftServer() == null)
             return 20;
-        }
 
         long[] ttl = internal.getMinecraftServer().tickTimeArray;
 
@@ -381,44 +393,43 @@ public class World {
     }
 
     /** Height of the ground for precipitation purposes at the given block */
-    public Vec3i getPrecipitationHeight(Vec3i pos) {
+    public Vec3i getPrecipitationHeight(final Vec3i pos) {
         return new Vec3i(internal.getPrecipitationHeight(pos.internal()));
     }
 
     /** Set the given pos to air */
-    public void setToAir(Vec3i pos) {
+    public void setToAir(final Vec3i pos) {
         internal.setBlockToAir(pos.internal());
     }
 
     /** If the block at pos is air */
-    public boolean isAir(Vec3i ph) {
+    public boolean isAir(final Vec3i ph) {
         return internal.isAirBlock(ph.internal());
     }
 
     /** Set the snow level to the given depth (1-8) */
-    public void setSnowLevel(Vec3i ph, int snowDown) {
+    public void setSnowLevel(final Vec3i ph, int snowDown) {
         snowDown = Math.max(1, Math.min(8, snowDown));
         if (snowDown == 8) {
             internal.setBlockState(ph.internal(), Blocks.SNOW.getDefaultState());
         } else {
-            internal.setBlockState(ph.internal(), Blocks.SNOW_LAYER.getDefaultState().withProperty(BlockSnow.LAYERS, snowDown));
+            internal.setBlockState(ph.internal(),
+                    Blocks.SNOW_LAYER.getDefaultState().withProperty(BlockSnow.LAYERS, snowDown));
         }
     }
 
     /** Get the snow level (1-8) */
-    public int getSnowLevel(Vec3i ph) {
+    public int getSnowLevel(final Vec3i ph) {
         IBlockState state = internal.getBlockState(ph.internal());
-        if (state.getBlock() == Blocks.SNOW_LAYER) {
+        if (state.getBlock() == Blocks.SNOW_LAYER)
             return state.getValue(BlockSnow.LAYERS);
-        }
-        if (state.getBlock() == Blocks.SNOW) {
+        if (state.getBlock() == Blocks.SNOW)
             return 8;
-        }
         return 0;
     }
 
     /** If this block is snow or snow layers */
-    public boolean isSnow(Vec3i ph) {
+    public boolean isSnow(final Vec3i ph) {
         Block block = internal.getBlockState(ph.internal()).getBlock();
         return block == Blocks.SNOW || block == Blocks.SNOW_LAYER;
     }
@@ -429,252 +440,256 @@ public class World {
     }
 
     /** If it is is raining */
-    public boolean isRaining(Vec3i position) {
+    public boolean isRaining(final Vec3i position) {
         return isPrecipitating() && internal.getBiome(position.internal()).canRain();
     }
 
     /** If it is snowing */
-    public boolean isSnowing(Vec3i position) {
+    public boolean isSnowing(final Vec3i position) {
         return isPrecipitating() && internal.getBiome(position.internal()).isSnowyBiome();
     }
 
     /** Temp in celsius */
-    public float getTemperature(Vec3i pos) {
+    public float getTemperature(final Vec3i pos) {
         float mctemp = internal.getBiome(pos.internal()).getTemperature(pos.internal());
-        //https://www.reddit.com/r/Minecraft/comments/3eh7yu/the_rl_temperature_of_minecraft_biomes_revealed/ctex050/
+        // https://www.reddit.com/r/Minecraft/comments/3eh7yu/the_rl_temperature_of_minecraft_biomes_revealed/ctex050/
         return (13.6484805403f * mctemp) + 7.0879687222f;
     }
 
     /** Drop a stack on the ground at pos */
-    public void dropItem(ItemStack stack, Vec3i pos) {
+    public void dropItem(final ItemStack stack, final Vec3i pos) {
         dropItem(stack, new Vec3d(pos), Vec3d.ZERO);
     }
 
     /** Drop a stack on the ground at pos */
-    public void dropItem(ItemStack stack, Vec3d pos) {
+    public void dropItem(final ItemStack stack, final Vec3d pos) {
         dropItem(stack, pos, Vec3d.ZERO);
     }
 
     /** Drop a stack on the ground at pos with velocity */
-    public void dropItem(ItemStack stack, Vec3d pos, Vec3d velocity) {
+    public void dropItem(final ItemStack stack, final Vec3d pos, final Vec3d velocity) {
         EntityItem entity = new EntityItem(internal, pos.x, pos.y, pos.z, stack.internal);
-        entity.setVelocity(velocity.x, velocity.y, velocity.z);
+        // entity.setVelocity(velocity.x, velocity.y, velocity.z);
         internal.spawnEntity(entity);
     }
 
     /** Check if the block is currently in a loaded chunk */
-    public boolean isBlockLoaded(Vec3i parent) {
+    public boolean isBlockLoaded(final Vec3i parent) {
         return internal.isBlockLoaded(parent.internal());
     }
 
     /** Check if block at pos collides with a BB */
-    public boolean doesBlockCollideWith(Vec3i bp, IBoundingBox bb) {
-        AxisAlignedBB cbb = internal.getBlockState(bp.internal()).getCollisionBoundingBox(internal, bp.internal());
-        if (cbb == null) {
-           return false;
-        }
+    public boolean doesBlockCollideWith(final Vec3i bp, final IBoundingBox bb) {
+        AxisAlignedBB cbb = internal.getBlockState(bp.internal()).getCollisionBoundingBox(internal,
+                bp.internal());
+        if (cbb == null)
+            return false;
         return bb.intersects(IBoundingBox.from(cbb.offset(bp.internal())));
     }
 
-    public List<Vec3i> blocksInBounds(IBoundingBox bb) {
+    public List<Vec3i> blocksInBounds(final IBoundingBox bb) {
         return internal.getCollisionBoxes(null, BoundingBox.from(bb)).stream()
                 .map(blockBox -> new Vec3i(blockBox.minX, blockBox.minY, blockBox.minZ))
                 .collect(Collectors.toList());
     }
 
     /** Break block (with in-world drops) */
-    public void breakBlock(Vec3i pos) {
+    public void breakBlock(final Vec3i pos) {
         this.breakBlock(pos, true);
     }
 
     /** Break block with sound effecnts, particles and optional drops */
-    public void breakBlock(Vec3i pos, boolean drop) {
+    public void breakBlock(final Vec3i pos, final boolean drop) {
         internal.destroyBlock(pos.internal(), drop);
     }
 
     /** If block is the given type */
-    public boolean isBlock(Vec3i pos, BlockType block) {
+    public boolean isBlock(final Vec3i pos, final BlockType block) {
         return internal.getBlockState(pos.internal()).getBlock() == block.internal;
     }
 
     /** Set block to a given block type */
-    public void setBlock(Vec3i pos, BlockType block) {
+    public void setBlock(final Vec3i pos, final BlockType block) {
         internal.setBlockState(pos.internal(), block.internal.getDefaultState());
     }
 
     /** Set a block to given stack (best guestimate) */
-    public void setBlock(Vec3i pos, ItemStack stack) {
-        IBlockState state = Block.getBlockFromItem(stack.internal.getItem()).getStateFromMeta(stack.internal.getMetadata());
+    public void setBlock(final Vec3i pos, final ItemStack stack) {
+        IBlockState state = Block.getBlockFromItem(stack.internal.getItem())
+                .getStateFromMeta(stack.internal.getMetadata());
         internal.setBlockState(pos.internal(), state);
     }
 
-    /** Is the top of the block solid?  Based on some AABB nonsense */
-    public boolean isTopSolid(Vec3i pos) {
+    /** Is the top of the block solid? Based on some AABB nonsense */
+    public boolean isTopSolid(final Vec3i pos) {
         return internal.getBlockState(pos.internal()).isTopSolid();
     }
 
     /** How hard is the block? */
-    public float getBlockHardness(Vec3i pos) {
+    public float getBlockHardness(final Vec3i pos) {
         return internal.getBlockState(pos.internal()).getBlockHardness(internal, pos.internal());
     }
 
     /** Get max redstone power surrounding this block */
-    public int getRedstone(Vec3i pos) {
+    public int getRedstone(final Vec3i pos) {
         int power = 0;
         for (Facing facing : Facing.values()) {
-            power = Math.max(power, internal.getRedstonePower(pos.offset(facing).internal(), facing.internal));
+            power = Math.max(power,
+                    internal.getRedstonePower(pos.offset(facing).internal(), facing.internal));
         }
         return power;
     }
 
     /** If the sky is visible at this position */
-    public boolean canSeeSky(Vec3i position) {
+    public boolean canSeeSky(final Vec3i position) {
         return internal.canSeeSky(position.internal());
     }
 
     /**
      * Some generic rules for if a block is replaceable
      *
-     * This mainly relies on Block.isReplaceable, but not all mod authors hook into it correctly.
+     * This mainly relies on Block.isReplaceable, but not all mod authors hook into
+     * it correctly.
      */
-    public boolean isReplaceable(Vec3i pos) {
-        if (isAir(pos)) {
+    public boolean isReplaceable(final Vec3i pos) {
+        if (isAir(pos))
             return true;
-        }
 
         Block block = internal.getBlockState(pos.internal()).getBlock();
 
-        if (block.isReplaceable(internal, pos.internal())) {
+        if (block.isReplaceable(internal, pos.internal()))
             return true;
-        }
-        if (block instanceof IGrowable && !(block instanceof BlockGrass)) {
+        if (block instanceof IGrowable && !(block instanceof BlockGrass))
             return true;
-        }
-        if (block instanceof IPlantable) {
+        if (block instanceof IPlantable)
             return true;
-        }
-        if (block instanceof BlockLiquid) {
+        if (block instanceof BlockLiquid)
             return true;
-        }
-        if (block instanceof BlockSnow) {
+        if (block instanceof BlockSnow)
             return true;
-        }
-        if (block instanceof BlockLeaves) {
+        if (block instanceof BlockLeaves)
             return true;
-        }
         return false;
     }
 
     /* Capabilities */
 
     /** Get the inventory at this block (accessed from any side) */
-    public IInventory getInventory(Vec3i offset) {
+    public IInventory getInventory(final Vec3i offset) {
         for (Facing value : Facing.values()) {
             IInventory inv = getInventory(offset, value);
-            if (inv != null) {
+            if (inv != null)
                 return inv;
-            }
         }
         return getInventory(offset, null);
     }
 
     /** Get the inventory at this block (accessed from given side) */
-    public IInventory getInventory(Vec3i offset, Facing dir) {
+    public IInventory getInventory(final Vec3i offset, final Facing dir) {
         net.minecraft.tileentity.TileEntity te = internal.getTileEntity(offset.internal());
         EnumFacing face = dir != null ? dir.internal : null;
         if (te != null && te.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, face)) {
-            IItemHandler inv = te.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, face);
-            if (inv instanceof IItemHandlerModifiable) {
+            IItemHandler inv =
+                    te.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, face);
+            if (inv instanceof IItemHandlerModifiable)
                 return IInventory.from((IItemHandlerModifiable) inv);
-            }
         }
         return null;
     }
 
     /** Get the tank at this block (accessed from any side) */
-    public List<ITank> getTank(Vec3i offset) {
+    public List<ITank> getTank(final Vec3i offset) {
         for (Facing value : Facing.values()) {
             List<ITank> tank = getTank(offset, value);
-            if (tank != null) {
+            if (tank != null)
                 return tank;
-            }
         }
         return getTank(offset, null);
     }
 
     /** Get the tank at this block (accessed from given side) */
-    public List<ITank> getTank(Vec3i offset, Facing dir) {
+    public List<ITank> getTank(final Vec3i offset, final Facing dir) {
         net.minecraft.tileentity.TileEntity te = internal.getTileEntity(offset.internal());
         EnumFacing face = dir != null ? dir.internal : null;
         if (te != null && te.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, face)) {
-            IFluidHandler tank = te.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, face);
-            if (tank != null) {
+            IFluidHandler tank =
+                    te.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, face);
+            if (tank != null)
                 return ITank.getTank(tank);
-            }
         }
         return null;
     }
 
     /** Get stack equiv of block at pos (Unreliable!) */
-    public ItemStack getItemStack(Vec3i pos) {
+    public ItemStack getItemStack(final Vec3i pos) {
         IBlockState state = internal.getBlockState(pos.internal());
         try {
             return new ItemStack(state.getBlock().getItem(internal, pos.internal(), state));
         } catch (Exception ex) {
-            return new ItemStack(new net.minecraft.item.ItemStack(state.getBlock(), 1, state.getBlock().damageDropped(state)));
+            return new ItemStack(new net.minecraft.item.ItemStack(state.getBlock(), 1,
+                    state.getBlock().damageDropped(state)));
         }
     }
 
     /** Get dropped items within the given area */
-    public List<ItemStack> getDroppedItems(IBoundingBox bb) {
-        List<EntityItem> items = internal.getEntitiesWithinAABB(EntityItem.class, BoundingBox.from(bb));
-        return items.stream().map((EntityItem::getItem)).map(ItemStack::new).collect(Collectors.toList());
+    public List<ItemStack> getDroppedItems(final IBoundingBox bb) {
+        List<EntityItem> items =
+                internal.getEntitiesWithinAABB(EntityItem.class, BoundingBox.from(bb));
+        return items.stream().map((EntityItem::getItem)).map(ItemStack::new)
+                .collect(Collectors.toList());
     }
 
-    /** Get a BlockInfo that can be used to overwrite a block in the future.  Does not currently include TE data */
-    public BlockInfo getBlock(Vec3i pos) {
+    /**
+     * Get a BlockInfo that can be used to overwrite a block in the future. Does not
+     * currently include TE data
+     */
+    public BlockInfo getBlock(final Vec3i pos) {
         return new BlockInfo(internal.getBlockState(pos.internal()));
     }
 
     /** Overwrite the block at pos from the given info */
-    public void setBlock(Vec3i pos, BlockInfo info) {
+    public void setBlock(final Vec3i pos, final BlockInfo info) {
         internal.removeTileEntity(pos.internal());
         internal.setBlockState(pos.internal(), info.internal);
     }
 
     /** Opt in collision overriding */
-    public boolean canEntityCollideWith(Vec3i bp, Entity entity) {
+    public boolean canEntityCollideWith(final Vec3i bp, final Entity entity) {
         IBlockState state = internal.getBlockState(bp.internal());
         Block block = state.getBlock();
 
-        if (block instanceof IConditionalCollision && ((IConditionalCollision) block).canCollide(internal, bp.internal(), state, entity.internal))
+        if (block instanceof IConditionalCollision && ((IConditionalCollision) block)
+                .canCollide(internal, bp.internal(), state, entity.internal))
             return true;
 
         if (block instanceof IBlockTypeBlock) {
             BlockType type = ((IBlockTypeBlock) block).getType();
-            if (type instanceof IBlockEntityCollision) {
+            if (type instanceof IBlockEntityCollision)
                 return ((IBlockEntityCollision) type).canCollide(this, bp, entity);
-            }
         }
         return false;
     }
 
     /** Spawn a particle */
-    public void createParticle(ParticleType type, Vec3d position, Vec3d velocity) {
-        internal.spawnParticle(type.internal, position.x, position.y, position.z, velocity.x, velocity.y, velocity.z);
+    public void createParticle(final ParticleType type, final Vec3d position,
+            final Vec3d velocity) {
+        internal.spawnParticle(type.internal, position.x, position.y, position.z, velocity.x,
+                velocity.y, velocity.z);
     }
 
     /**
      *
-     * Updates the blocks around the position.
-     * Value updateObservers will be ignored in some MC versions.
+     * Updates the blocks around the position. Value updateObservers will be ignored
+     * in some MC versions.
      *
      * @param pos
      * @param blockType
      * @param updateObservers
      */
-    public void notifyNeighborsOfStateChange(Vec3i pos, BlockType blockType, boolean updateObservers){
-        this.internal.notifyNeighborsOfStateChange(pos.internal(), blockType.internal, updateObservers);
+    public void notifyNeighborsOfStateChange(final Vec3i pos, final BlockType blockType,
+            final boolean updateObservers) {
+        this.internal.notifyNeighborsOfStateChange(pos.internal(), blockType.internal,
+                updateObservers);
     }
 
     public enum ParticleType {
@@ -684,16 +699,16 @@ public class World {
 
         private final EnumParticleTypes internal;
 
-        ParticleType(EnumParticleTypes internal) {
+        ParticleType(final EnumParticleTypes internal) {
             this.internal = internal;
         }
     }
 
-    public float getBlockLightLevel(Vec3i pos) {
+    public float getBlockLightLevel(final Vec3i pos) {
         return internal.getLightFor(EnumSkyBlock.BLOCK, pos.internal()) / 15f;
     }
 
-    public float getSkyLightLevel(Vec3i pos) {
+    public float getSkyLightLevel(final Vec3i pos) {
         return internal.getLightFor(EnumSkyBlock.SKY, pos.internal()) / 15f;
     }
 }


### PR DESCRIPTION
Hey, I've noticed a bug with UMC on my custom server, when a player disconnects and reconnects to the server, they can't interact with IR trains and tracks. I reported this here a long time ago: https://github.com/TeamOpenIndustry/ImmersiveRailroading/issues/1388
It then throws the error ‘Invalid packet missing player’ every time. The logs are attached.
Now I have investigated the problem further and found that when the player disconnects from the game, he is not removed from the loadedEntityList of the world. Adding this code fixes the problem and does not affect any other server applications.


![bug2](https://github.com/user-attachments/assets/64b4af81-5828-47f3-a040-4ff38a043304)
![bug](https://github.com/user-attachments/assets/24e48713-fc3f-4c17-a0cc-c6fb3fdffe5e)
