### PR TITLE
1.7.10 forge - fix crashes and bugs related to MinecraftClient.getPlayer()

### DIFF
--- a/src/main/java/cam72cam/mod/MinecraftClient.java
+++ b/src/main/java/cam72cam/mod/MinecraftClient.java
@@ -23,7 +23,7 @@ public class MinecraftClient {
         if (internal == null) {
             throw new RuntimeException("Called to get the player before minecraft has actually started!");
         }
-        if (playerCache == null || internal != playerCache.internal) {
+        if ((playerCache == null || internal != playerCache.internal) && !(internal.worldObj == null || World.get(internal.worldObj) == null || internal.getUniqueID() == null || World.get(internal.worldObj).getEntity(internal) == null)) {
             playerCache = World.get(internal.worldObj).getEntity(internal).asPlayer();
         }
         return playerCache;

--- a/src/main/java/cam72cam/mod/MinecraftClient.java
+++ b/src/main/java/cam72cam/mod/MinecraftClient.java
@@ -13,7 +13,7 @@ import net.minecraft.client.entity.EntityPlayerSP;
 public class MinecraftClient {
     /** Minecraft is loaded and has a loaded world */
     public static boolean isReady() {
-        return Minecraft.getMinecraft().thePlayer != null && Minecraft.getMinecraft().theWorld != null;
+        return Minecraft.getMinecraft().thePlayer != null && Minecraft.getMinecraft().theWorld != null && getPlayer() != null;
     }
 
     private static Player playerCache;
@@ -41,6 +41,9 @@ public class MinecraftClient {
 
     /** Entity that you are currently looking at (distance limited) */
     public static Entity getEntityMouseOver() {
+        if (getPlayer() == null){
+            return null;
+        }
         net.minecraft.entity.Entity ent = Minecraft.getMinecraft().objectMouseOver.entityHit;
         if (ent != null) {
             return getPlayer().getWorld().getEntity(ent.getUniqueID(), Entity.class);

--- a/src/main/java/cam72cam/mod/render/GlobalRender.java
+++ b/src/main/java/cam72cam/mod/render/GlobalRender.java
@@ -87,8 +87,8 @@ public class GlobalRender {
     /** Register a function that is called to render during the mouse over phase (only if a block is moused over) */
     public static void registerItemMouseover(CustomItem item, MouseoverEvent fn) {
         ClientEvents.RENDER_MOUSEOVER.subscribe(partialTicks -> {
-            if (MinecraftClient.getBlockMouseOver() != null) {
-                Player player = MinecraftClient.getPlayer();
+            Player player = MinecraftClient.getPlayer();
+            if (player != null && MinecraftClient.getBlockMouseOver() != null) {
                 if (!player.getHeldItem(Player.Hand.PRIMARY).isEmpty() && item.internal == player.getHeldItem(Player.Hand.PRIMARY).internal.getItem()) {
                     fn.render(player, player.getHeldItem(Player.Hand.PRIMARY), MinecraftClient.getBlockMouseOver(), MinecraftClient.getPosMouseOver(), new RenderState(), partialTicks);
                 }

--- a/src/main/java/cam72cam/mod/render/ItemRender.java
+++ b/src/main/java/cam72cam/mod/render/ItemRender.java
@@ -271,6 +271,7 @@ public class ItemRender {
 
         @Override
         public void renderItem(ItemRenderType typeIn, net.minecraft.item.ItemStack item, Object... data) {
+            if (!MinecraftClient.isReady()) { return; }
             ItemStack stack = new ItemStack(item);
             if (stack.isEmpty()) {
                 return;


### PR DESCRIPTION
When changing dimensions, MinecraftClient.getPlayer() could return null. This, along with my pr for Immersive Railroading, will fix these and other bugs for 1.7.10.