### PR TITLE
Fix for CI/CD: actions/upload-artifact@v2-preview => actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
               env:
                 MAVENCI_PASS: ${{ secrets.MAVENCI_PASS }}
               run: ./gradlew publish
-            - uses: actions/upload-artifact@v2-preview
+            - uses: actions/upload-artifact@v4
               with:
                 name: UniversalModCore-${{ env.ref }}
                 path: build/libs/UniversalModCore-*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
               env:
                 MAVENCI_PASS: ${{ secrets.MAVENCI_PASS }}
               run: ./gradlew publish -Dtarget=release
-            - uses: actions/upload-artifact@v2-preview
+            - uses: actions/upload-artifact@v4
               with:
                 name: UniversalModCore-${{ env.ref }}
                 path: build/libs/UniversalModCore-*.jar


### PR DESCRIPTION
We're currently having issues with a failed build for 1.7.10 as upload-artifact@v2-preview is no longer supported.
This should fix the issue and enable the builds to succeed. 
Needs to be merged upwards and downwards the mc versions.