### PR TITLE
[1.12.2] Fixed missing passenger position sync.

### DIFF
--- a/src/main/java/cam72cam/mod/entity/ModdedEntity.java
+++ b/src/main/java/cam72cam/mod/entity/ModdedEntity.java
@@ -365,6 +365,10 @@ public class ModdedEntity extends Entity implements IEntityAdditionalSpawnData {
             passenger.internal.rotationYaw = passenger.internal.rotationYaw + delta;
 
             seat.shouldSit = iRidable.shouldRiderSit(passenger);
+
+            if (self.getWorld().isServer) {
+                new PassengerPositionsPacket(this).sendToObserving(self);
+            }
         }
     }
 


### PR DESCRIPTION
Quick and dirty fix for the missing syncronization between server and client for the updated player position. It's probably not the best fix for it, but it was the quickest I could find.