### PR TITLE
[Feature] add back 1.12.2-like checkbox for 1.14.4

### DIFF
--- a/src/main/java/cam72cam/mod/gui/screen/CheckBox.java
+++ b/src/main/java/cam72cam/mod/gui/screen/CheckBox.java
@@ -2,28 +2,26 @@ package cam72cam.mod.gui.screen;
 
 
 import cam72cam.mod.entity.Player;
+import net.minecraft.client.gui.widget.button.CheckboxButton;
 
 /** Basic checkbox */
 public abstract class CheckBox extends Button {
     public CheckBox(IScreenBuilder builder, int x, int y, String text, boolean enabled) {
-        super(builder, x-25, y, 200, 20, (enabled ? "X" : "█") + " " + text);
+//        super(builder, x, y, 200, 20, (enabled ? "X" : "█") + " " + text);
+        super(builder, new CheckboxButton(builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, 100, 20, text, enabled));
     }
 
     public boolean isChecked() {
-        return button.getMessage().contains("X");
+        return ((CheckboxButton)button).isChecked();
     }
 
     @Override
     protected void onClickInternal(Player.Hand hand) {
-        this.setChecked(!this.isChecked());
+        this.setChecked();
         super.onClickInternal(hand);
     }
 
-    public void setChecked(boolean val) {
-        if (val) {
-            button.setMessage(button.getMessage().replace("█", "X"));
-        } else {
-            button.setMessage(button.getMessage().replace("X", "█"));
-        }
+    public void setChecked() {
+        ((CheckboxButton)button).onPress();
     }
 }


### PR DESCRIPTION
In 1.14.4 net.minecraftforge.fml.client.config.GuiCheckBox changed a lot, but net.minecraft.client.gui.widget.button.CheckboxButton almost remains the same as 1.12.2's, like
<img width="1920" height="1001" alt="2025-08-08_08 41 34" src="https://github.com/user-attachments/assets/b547b8fc-9169-4fee-a4f4-5bf2644a604a" />
