### PR TITLE
[Breaking Mainline Feature] Add ItemEntity wrapper

### DIFF
--- a/src/main/java/cam72cam/mod/entity/ItemEntity.java
+++ b/src/main/java/cam72cam/mod/entity/ItemEntity.java
@@ -2,19 +2,24 @@ package cam72cam.mod.entity;
 
 import cam72cam.mod.item.ItemStack;
 import cam72cam.mod.world.World;
+import net.minecraft.entity.item.EntityItem;
 
 /**
  * Represents an item entity in the world, wrapping Minecraft's EntityItem.
  */
 public class ItemEntity extends Entity {
-    public net.minecraft.entity.item.EntityItem internal;
+    public final EntityItem internal;
 
-    public ItemEntity(net.minecraft.entity.item.EntityItem entity) {
+    public ItemEntity(EntityItem entity) {
         super(entity);
         this.internal = entity;
     }
 
     public ItemStack getContent() {
+        if (!isValid()) {
+            return ItemStack.EMPTY;
+        }
+
         return new ItemStack(internal.getItem());
     }
 
@@ -24,9 +29,14 @@ public class ItemEntity extends Entity {
      * @return the player allowed to pick up this item, or null if no owner is set
      */
     public Player getOwner() {
+        if (!isValid()) {
+            return null;
+        }
+
         if (internal.getOwner() == null || this.internal.getEntityWorld().getPlayerEntityByName(internal.getOwner()) == null) {
             return null;
         }
+
         return World.get(this.internal.world)
                     .getEntity(this.internal.getEntityWorld()
                                             .getPlayerEntityByName(internal.getOwner())).asPlayer();
@@ -38,7 +48,9 @@ public class ItemEntity extends Entity {
      * @param player the player to set as the owner
      */
     public void setOwner(Player player) {
-        internal.setOwner(player.internal.getName());
+        if (isValid()) {
+            internal.setOwner(player.internal.getName());
+        }
     }
 
     /**
@@ -47,6 +59,10 @@ public class ItemEntity extends Entity {
      * @return the player who threw the item, or null if not thrown by a player
      */
     public Player getThrower() {
+        if (!isValid()) {
+            return null;
+        }
+
         if (internal.getThrower() == null || this.internal.getEntityWorld().getPlayerEntityByName(internal.getThrower()) == null) {
             return null;
         }
@@ -61,13 +77,27 @@ public class ItemEntity extends Entity {
      * @param ticks the minimum delay in ticks before the item can be picked up
      */
     public void setPickupDelay(int ticks) {
-        internal.setPickupDelay(ticks);
+        if (isValid()) {
+            internal.setPickupDelay(ticks);
+        }
+
     }
 
     /**
      * Prevents this item entity from despawning naturally.
      */
     public void setNoDespawn() {
-        internal.setNoDespawn();
+        if (isValid()) {
+            internal.setNoDespawn();
+        }
+
+    }
+
+    /**
+     * Return true if this item entity is still in the world and interactable.
+     * If false, operations on this entity will be no-ops.
+     */
+    public boolean isValid() {
+        return internal != null && !internal.isDead;
     }
 }

--- a/src/main/java/cam72cam/mod/entity/ItemEntity.java
+++ b/src/main/java/cam72cam/mod/entity/ItemEntity.java
@@ -23,6 +23,10 @@ public class ItemEntity extends Entity {
         return new ItemStack(internal.getItem());
     }
 
+    public void setContent(ItemStack stack) {
+        internal.setItem(stack.internal);
+    }
+
     /**
      * Retrieves the owner of this item entity. Only the owner can pick it up.
      *

--- a/src/main/java/cam72cam/mod/entity/ItemEntity.java
+++ b/src/main/java/cam72cam/mod/entity/ItemEntity.java
@@ -1,0 +1,73 @@
+package cam72cam.mod.entity;
+
+import cam72cam.mod.item.ItemStack;
+import cam72cam.mod.world.World;
+
+/**
+ * Represents an item entity in the world, wrapping Minecraft's EntityItem.
+ */
+public class ItemEntity extends Entity {
+    public net.minecraft.entity.item.EntityItem internal;
+
+    public ItemEntity(net.minecraft.entity.item.EntityItem entity) {
+        super(entity);
+        this.internal = entity;
+    }
+
+    public ItemStack getContent() {
+        return new ItemStack(internal.getItem());
+    }
+
+    /**
+     * Retrieves the owner of this item entity. Only the owner can pick it up.
+     *
+     * @return the player allowed to pick up this item, or null if no owner is set
+     */
+    public Player getOwner() {
+        if (internal.getOwner() == null || this.internal.getEntityWorld().getPlayerEntityByName(internal.getOwner()) == null) {
+            return null;
+        }
+        return World.get(this.internal.world)
+                    .getEntity(this.internal.getEntityWorld()
+                                            .getPlayerEntityByName(internal.getOwner())).asPlayer();
+    }
+
+    /**
+     * Sets the owner of this item entity. Only the owner can pick it up.
+     *
+     * @param player the player to set as the owner
+     */
+    public void setOwner(Player player) {
+        internal.setOwner(player.internal.getName());
+    }
+
+    /**
+     * Retrieves the player who threw this item entity.
+     *
+     * @return the player who threw the item, or null if not thrown by a player
+     */
+    public Player getThrower() {
+        if (internal.getThrower() == null || this.internal.getEntityWorld().getPlayerEntityByName(internal.getThrower()) == null) {
+            return null;
+        }
+        return World.get(this.internal.world)
+                    .getEntity(this.internal.getEntityWorld()
+                                            .getPlayerEntityByName(internal.getThrower())).asPlayer();
+    }
+
+    /**
+     * Sets the pickup delay for this item entity.
+     *
+     * @param ticks the minimum delay in ticks before the item can be picked up
+     */
+    public void setPickupDelay(int ticks) {
+        internal.setPickupDelay(ticks);
+    }
+
+    /**
+     * Prevents this item entity from despawning naturally.
+     */
+    public void setNoDespawn() {
+        internal.setNoDespawn();
+    }
+}

--- a/src/main/java/cam72cam/mod/world/World.java
+++ b/src/main/java/cam72cam/mod/world/World.java
@@ -176,6 +176,8 @@ public class World {
             entity = new Player((EntityPlayer) entityIn);
         } else if (entityIn instanceof EntityLiving) {
             entity = new Living((EntityLiving) entityIn);
+        } else if (entityIn instanceof EntityItem) {
+            entity = new cam72cam.mod.entity.ItemEntity((EntityItem) entityIn);
         } else {
             entity = new Entity(entityIn);
         }
@@ -622,6 +624,13 @@ public class World {
     public List<ItemStack> getDroppedItems(IBoundingBox bb) {
         List<EntityItem> items = internal.getEntitiesWithinAABB(EntityItem.class, BoundingBox.from(bb));
         return items.stream().map((EntityItem::getItem)).map(ItemStack::new).collect(Collectors.toList());
+    }
+
+    /** Get dropped items within the given area in entity form*/
+    public List<cam72cam.mod.entity.ItemEntity> getDroppedItemEntities(IBoundingBox bb) {
+        return internal.getEntitiesWithinAABB(EntityItem.class, BoundingBox.from(bb)).stream()
+                       .map(itemEntity ->  this.getEntity(itemEntity.getEntityId(), cam72cam.mod.entity.ItemEntity.class))
+                       .collect(Collectors.toList());
     }
 
     /** Get a BlockInfo that can be used to overwrite a block in the future.  Does not currently include TE data */

--- a/src/main/java/cam72cam/mod/world/World.java
+++ b/src/main/java/cam72cam/mod/world/World.java
@@ -628,13 +628,6 @@ public class World {
         return items.stream().map((EntityItem::getItem)).map(ItemStack::new).collect(Collectors.toList());
     }
 
-    /** Get dropped items within the given area in entity form*/
-    public List<cam72cam.mod.entity.ItemEntity> getDroppedItemEntities(IBoundingBox bb) {
-        return internal.getEntitiesWithinAABB(EntityItem.class, BoundingBox.from(bb)).stream()
-                       .map(itemEntity ->  this.getEntity(itemEntity.getEntityId(), cam72cam.mod.entity.ItemEntity.class))
-                       .collect(Collectors.toList());
-    }
-
     /** Get a BlockInfo that can be used to overwrite a block in the future.  Does not currently include TE data */
     public BlockInfo getBlock(Vec3i pos) {
         return new BlockInfo(internal.getBlockState(pos.internal()));

--- a/src/main/java/cam72cam/mod/world/World.java
+++ b/src/main/java/cam72cam/mod/world/World.java
@@ -24,11 +24,9 @@ import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
-import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.math.AxisAlignedBB;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.IPlantable;
@@ -441,20 +439,24 @@ public class World {
     }
 
     /** Drop a stack on the ground at pos */
-    public void dropItem(ItemStack stack, Vec3i pos) {
-        dropItem(stack, new Vec3d(pos), Vec3d.ZERO);
+    public ItemEntity dropItem(ItemStack stack, Vec3i pos) {
+        return dropItem(stack, new Vec3d(pos), Vec3d.ZERO);
     }
 
     /** Drop a stack on the ground at pos */
-    public void dropItem(ItemStack stack, Vec3d pos) {
-        dropItem(stack, pos, Vec3d.ZERO);
+    public ItemEntity dropItem(ItemStack stack, Vec3d pos) {
+        return dropItem(stack, pos, Vec3d.ZERO);
     }
 
-    /** Drop a stack on the ground at pos with velocity */
-    public void dropItem(ItemStack stack, Vec3d pos, Vec3d velocity) {
+    /** Drop a stack on the ground at pos with velocity.
+     * <p>
+     * Note that if system property <code>forge.debugBlockSnapshot</code> is true and forge is capturing block snapshot, item entity will not be spawned and this method will return null!
+     */
+    public ItemEntity dropItem(ItemStack stack, Vec3d pos, Vec3d velocity) {
         EntityItem entity = new EntityItem(internal, pos.x, pos.y, pos.z, stack.internal);
         entity.setVelocity(velocity.x, velocity.y, velocity.z);
         internal.spawnEntity(entity);
+        return getEntity(entity.getUniqueID(), ItemEntity.class);
     }
 
     /** Check if the block is currently in a loaded chunk */


### PR DESCRIPTION
This PR adds wrapper for ItemEntity similar to `Player` to enable more precise control over items in world with UMC

Breaks bytecode compatibility, mods will need to re-build to catch up with this feature