### PR TITLE
[Mainline Feature] Introduce mixin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,11 +88,12 @@ dependencies {
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
 	shade "curse.maven:invtweaks-223094:2482482"
 
-    shade('org.spongepowered:mixin:0.7.11-SNAPSHOT') {
+    shade('org.spongepowered:mixin:0.8.3') {
         exclude module: 'guava'
         exclude module: 'commons-io'
         exclude module: 'gson'
     }
+    shade('io.github.llamalad7:mixinextras-common:0.5.0')
     testCompile('junit:junit:4.13.1')
 
     shade group: 'org.lz4', name: 'lz4-java', version: '1.7.1'
@@ -113,13 +114,18 @@ jar {
         )
     }
 
+    def serviceDir = file("$buildDir/tmp/services_cleanup/META-INF/services")
+    serviceDir.deleteDir()
+    serviceDir.mkdirs()
+
     configurations.shade.each { dep ->
         from(project.zipTree(dep)){
             exclude 'META-INF', 'META-INF/**'
         }
-
-        from(project.zipTree(dep)){
-            include 'META-INF/services', 'META-INF/services/**'
+        zipTree(dep).matching {
+            include 'META-INF/services/*'
+        }.each { serviceFile ->
+            new File(serviceDir, serviceFile.name) << serviceFile.getText("UTF-8") << '\n'
         }
     }
 }
@@ -148,10 +154,19 @@ processResources {
 shadowJar {
     classifier = ''
     configurations = [project.configurations.shade]
-    relocate 'com.llamalad7.mixinextras', "${project.group}.shade.mixinextras"
+    relocate 'com.llamalad7', "${project.group}.shade.com.llamalad7"
+    relocate 'net.jpountz', "${project.group}.shade.net.jpountz"
+    //Don't do this
+//    relocate 'org.spongepowered', "${project.group}.shade.org.spongepowered"
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     mergeServiceFiles()
     finalizedBy 'reobfShadowJar'
+}
+
+assemble.dependsOn shadowJar
+
+reobf {
+    shadowJar {}
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,8 @@ minecraft {
     runDir = "run"
 
     coreMod = 'cam72cam.mod.UMCMixinLoadingPlugin'
-    clientRunArgs.addAll('--tweakClass', 'org.spongepowered.asm.launch.MixinTweaker', '--mixin', 'mixins.universalmodcore.json')
-    serverRunArgs.addAll('--tweakClass', 'org.spongepowered.asm.launch.MixinTweaker', '--mixin', 'mixins.universalmodcore.json')
+//    clientRunArgs.addAll('--tweakClass', 'org.spongepowered.asm.launch.MixinTweaker', '--mixin', 'mixins.universalmodcore.json')
+//    serverRunArgs.addAll('--tweakClass', 'org.spongepowered.asm.launch.MixinTweaker', '--mixin', 'mixins.universalmodcore.json')
     // the mappings can be changed at any time, and must be in the following format.
     // snapshot_YYYYMMDD   snapshot are built nightly.
     // stable_#            stables are built at the discretion of the MCP team.
@@ -58,7 +58,7 @@ minecraft {
 }
 
 repositories {
-    maven { url = 'https://repo.spongepowered.org/maven' }
+    maven { url = "https://repo.spongepowered.org/maven" }
 }
 
 configurations {
@@ -89,12 +89,12 @@ dependencies {
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
 	shade "curse.maven:invtweaks-223094:2482482"
 
-    embed 'org.spongepowered:mixin:0.8'
-    annotationProcessor 'org.ow2.asm:asm-debug-all:5.2'
-    annotationProcessor 'com.google.guava:guava:32.1.2-jre'
-    annotationProcessor 'com.google.code.gson:gson:2.8.9'
-    annotationProcessor 'org.spongepowered:mixin:0.8'
-    testCompile('junit:junit:4.13')
+    provided('org.spongepowered:mixin:0.7.11-SNAPSHOT') {
+        exclude module: 'guava'
+        exclude module: 'commons-io'
+        exclude module: 'gson'
+    }
+    testCompile('junit:junit:4.13.1')
 
     shade group: 'org.lz4', name: 'lz4-java', version: '1.7.1'
 }
@@ -104,26 +104,22 @@ mixin {
 }
 
 jar {
+    from configurations.provided.asFileTree.files.collect {
+        zipTree(it)
+    }
     configurations.shade.each { dep ->
         from(project.zipTree(dep)){
             exclude 'META-INF', 'META-INF/**'
         }
     }
 
-    from(configurations.embed.collect {
-        it.isDirectory() ? it : zipTree(it)
-    }) {
-        exclude 'LICENSE.txt', 'META-INF/MANIFSET.MF', 'META-INF/maven/**', 'META-INF/*.RSA', 'META-INF/*.SF'
-    }
-
     manifest {
         attributes (
                 'FMLAT': 'UniversalModCore_at.cfg',
                 'FMLCorePluginContainsFMLMod': true,
-                'FMLCorePlugin': 'cam72cam.mod.UMCMixinLoadingPlugin',
-                'ForceLoadAsMod': true,
+                'TweakOrder': '0',
                 'TweakClass': 'org.spongepowered.asm.launch.MixinTweaker',
-                'MixinConfigs': 'mixins.universalmodcore.json'
+                "MixinConfigs": "mixins.universalmodcore.json"
         )
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,11 @@
 buildscript {
     repositories {
         maven { url = "https://maven.minecraftforge.net/" }
+        maven { url = 'https://repo.spongepowered.org/maven' }
     }
 	dependencies {
         classpath 'net.minecraftforge.gradle:ForgeGradle:2.3.2'
+        classpath 'org.spongepowered:mixingradle:0.6-SNAPSHOT'
 	}
 }
 
@@ -14,6 +16,7 @@ configurations {
 
 apply plugin: 'net.minecraftforge.gradle.forge'
 apply plugin: 'maven-publish'
+apply plugin: 'org.spongepowered.mixin'
 
 repositories {
     maven {
@@ -41,7 +44,10 @@ compileJava {
 minecraft {
     version = "1.12.2-14.23.5.2847"
     runDir = "run"
-    
+
+    coreMod = 'cam72cam.mod.UMCMixinLoadingPlugin'
+    clientRunArgs.addAll('--tweakClass', 'org.spongepowered.asm.launch.MixinTweaker', '--mixin', 'mixins.universalmodcore.json')
+    serverRunArgs.addAll('--tweakClass', 'org.spongepowered.asm.launch.MixinTweaker', '--mixin', 'mixins.universalmodcore.json')
     // the mappings can be changed at any time, and must be in the following format.
     // snapshot_YYYYMMDD   snapshot are built nightly.
     // stable_#            stables are built at the discretion of the MCP team.
@@ -49,6 +55,15 @@ minecraft {
     // simply re-run your setup task after changing the mappings to update your workspace.
     mappings = "stable_39"
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
+}
+
+repositories {
+    maven { url = 'https://repo.spongepowered.org/maven' }
+}
+
+configurations {
+    embed
+    compile.extendsFrom(embed)
 }
 
 dependencies {
@@ -74,9 +89,18 @@ dependencies {
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
 	shade "curse.maven:invtweaks-223094:2482482"
 
+    embed 'org.spongepowered:mixin:0.8'
+    annotationProcessor 'org.ow2.asm:asm-debug-all:5.2'
+    annotationProcessor 'com.google.guava:guava:32.1.2-jre'
+    annotationProcessor 'com.google.code.gson:gson:2.8.9'
+    annotationProcessor 'org.spongepowered:mixin:0.8'
     testCompile('junit:junit:4.13')
 
     shade group: 'org.lz4', name: 'lz4-java', version: '1.7.1'
+}
+
+mixin {
+    add sourceSets.main, 'mixins.universalmodcore.refmap.json'
 }
 
 jar {
@@ -85,25 +109,40 @@ jar {
             exclude 'META-INF', 'META-INF/**'
         }
     }
+
+    from(configurations.embed.collect {
+        it.isDirectory() ? it : zipTree(it)
+    }) {
+        exclude 'LICENSE.txt', 'META-INF/MANIFSET.MF', 'META-INF/maven/**', 'META-INF/*.RSA', 'META-INF/*.SF'
+    }
+
     manifest {
-        attributes 'FMLAT': 'UniversalModCore_at.cfg'
+        attributes (
+                'FMLAT': 'UniversalModCore_at.cfg',
+                'FMLCorePluginContainsFMLMod': true,
+                'FMLCorePlugin': 'cam72cam.mod.UMCMixinLoadingPlugin',
+                'ForceLoadAsMod': true,
+                'TweakClass': 'org.spongepowered.asm.launch.MixinTweaker',
+                'MixinConfigs': 'mixins.universalmodcore.json'
+        )
     }
 }
+
 jar.finalizedBy('reobfJar')
 
 processResources {
     // this will ensure that this task is redone when the versions change.
-    inputs.property "version", project.version
-    inputs.property "mcversion", project.minecraft.version
+    inputs.property 'version', project.version
+    inputs.property 'mcversion', project.minecraft.version
 
     // replace stuff in mcmod.info, nothing else
     from(sourceSets.main.resources.srcDirs) {
         include 'mcmod.info'
-                
+
         // replace version and mcversion
         expand 'version':project.version, 'mcversion':project.minecraft.version
     }
-        
+
     // copy everything else except the mcmod.info
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info'

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
         maven { url = "https://maven.minecraftforge.net/" }
+        maven { url "https://plugins.gradle.org/" }
         maven { url = 'https://repo.spongepowered.org/maven' }
+        mavenCentral()
     }
 	dependencies {
         classpath 'net.minecraftforge.gradle:ForgeGradle:2.3.2'
+        classpath 'com.github.johnrengelman.shadow:com.github.johnrengelman.shadow.gradle.plugin:2.0.4'
         classpath 'org.spongepowered:mixingradle:0.6-SNAPSHOT'
 	}
 }
@@ -16,6 +19,7 @@ configurations {
 
 apply plugin: 'net.minecraftforge.gradle.forge'
 apply plugin: 'maven-publish'
+apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'org.spongepowered.mixin'
 
 repositories {
@@ -45,7 +49,7 @@ minecraft {
     version = "1.12.2-14.23.5.2847"
     runDir = "run"
 
-    coreMod = 'cam72cam.mod.UMCMixinLoadingPlugin'
+    coreMod = 'cam72cam.mod.UMCMixinPlugin'
 //    clientRunArgs.addAll('--tweakClass', 'org.spongepowered.asm.launch.MixinTweaker', '--mixin', 'mixins.universalmodcore.json')
 //    serverRunArgs.addAll('--tweakClass', 'org.spongepowered.asm.launch.MixinTweaker', '--mixin', 'mixins.universalmodcore.json')
     // the mappings can be changed at any time, and must be in the following format.
@@ -59,11 +63,6 @@ minecraft {
 
 repositories {
     maven { url = "https://repo.spongepowered.org/maven" }
-}
-
-configurations {
-    embed
-    compile.extendsFrom(embed)
 }
 
 dependencies {
@@ -89,7 +88,7 @@ dependencies {
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
 	shade "curse.maven:invtweaks-223094:2482482"
 
-    provided('org.spongepowered:mixin:0.7.11-SNAPSHOT') {
+    shade('org.spongepowered:mixin:0.7.11-SNAPSHOT') {
         exclude module: 'guava'
         exclude module: 'commons-io'
         exclude module: 'gson'
@@ -104,15 +103,6 @@ mixin {
 }
 
 jar {
-    from configurations.provided.asFileTree.files.collect {
-        zipTree(it)
-    }
-    configurations.shade.each { dep ->
-        from(project.zipTree(dep)){
-            exclude 'META-INF', 'META-INF/**'
-        }
-    }
-
     manifest {
         attributes (
                 'FMLAT': 'UniversalModCore_at.cfg',
@@ -121,6 +111,16 @@ jar {
                 'TweakClass': 'org.spongepowered.asm.launch.MixinTweaker',
                 "MixinConfigs": "mixins.universalmodcore.json"
         )
+    }
+
+    configurations.shade.each { dep ->
+        from(project.zipTree(dep)){
+            exclude 'META-INF', 'META-INF/**'
+        }
+
+        from(project.zipTree(dep)){
+            include 'META-INF/services', 'META-INF/services/**'
+        }
     }
 }
 
@@ -143,6 +143,15 @@ processResources {
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info'
     }
+}
+
+shadowJar {
+    classifier = ''
+    configurations = [project.configurations.shade]
+    relocate 'com.llamalad7.mixinextras', "${project.group}.shade.mixinextras"
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    mergeServiceFiles()
+    finalizedBy 'reobfShadowJar'
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Mar 28 07:25:48 EDT 2022
+#Wed Sep 03 18:26:21 CST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Sep 03 18:26:21 CST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip

--- a/src/main/java/cam72cam/mod/UMCMixinLoadingPlugin.java
+++ b/src/main/java/cam72cam/mod/UMCMixinLoadingPlugin.java
@@ -1,0 +1,43 @@
+package cam72cam.mod;
+
+
+import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
+import org.spongepowered.asm.launch.MixinBootstrap;
+import org.spongepowered.asm.mixin.Mixins;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+@IFMLLoadingPlugin.MCVersion("1.12.2")
+public class UMCMixinLoadingPlugin implements IFMLLoadingPlugin {
+    public UMCMixinLoadingPlugin() {
+        MixinBootstrap.init();
+        Mixins.addConfiguration("mixins.universalmodcore.json");
+    }
+
+    @Override
+    public String[] getASMTransformerClass() {
+        return new String[0];
+    }
+
+    @Override
+    public String getModContainerClass() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getSetupClass() {
+        return null;
+    }
+
+    @Override
+    public void injectData(Map<String, Object> data) {
+
+    }
+
+    @Override
+    public String getAccessTransformerClass() {
+        return null;
+    }
+}

--- a/src/main/java/cam72cam/mod/UMCMixinLoadingPlugin.java
+++ b/src/main/java/cam72cam/mod/UMCMixinLoadingPlugin.java
@@ -1,6 +1,5 @@
 package cam72cam.mod;
 
-
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
 import org.spongepowered.asm.launch.MixinBootstrap;
 import org.spongepowered.asm.mixin.Mixins;

--- a/src/main/java/cam72cam/mod/UMCMixinLoadingPlugin.java
+++ b/src/main/java/cam72cam/mod/UMCMixinLoadingPlugin.java
@@ -1,10 +1,16 @@
 package cam72cam.mod;
 
+import net.minecraftforge.fml.relauncher.CoreModManager;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
+import org.apache.logging.log4j.LogManager;
 import org.spongepowered.asm.launch.MixinBootstrap;
 import org.spongepowered.asm.mixin.Mixins;
 
 import javax.annotation.Nullable;
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.CodeSource;
 import java.util.Map;
 
 @IFMLLoadingPlugin.MCVersion("1.12.2")
@@ -12,6 +18,23 @@ public class UMCMixinLoadingPlugin implements IFMLLoadingPlugin {
     public UMCMixinLoadingPlugin() {
         MixinBootstrap.init();
         Mixins.addConfiguration("mixins.universalmodcore.json");
+
+        //https://github.com/ReplayMod/ReplayMod/blob/ec50efec104c8345a3a4f20fd44cfb3608cd81bb/src/main/java/com/replaymod/core/LoadingPlugin.java
+        CodeSource codeSource = this.getClass().getProtectionDomain().getCodeSource();
+        if (codeSource != null) {
+            URL location = codeSource.getLocation();
+            try {
+                File file = new File(location.toURI());
+                if (file.isFile()) {
+                    CoreModManager.getIgnoredMods().remove(file.getName());
+                }
+            } catch (URISyntaxException e) {
+                e.printStackTrace();
+            }
+        } else {
+            LogManager.getLogger().warn("No CodeSource, if this is not a development environment we might run into problems!");
+            LogManager.getLogger().warn(this.getClass().getProtectionDomain());
+        }
     }
 
     @Override

--- a/src/main/java/cam72cam/mod/UMCMixinPlugin.java
+++ b/src/main/java/cam72cam/mod/UMCMixinPlugin.java
@@ -1,5 +1,6 @@
 package cam72cam.mod;
 
+import com.llamalad7.mixinextras.MixinExtrasBootstrap;
 import net.minecraftforge.fml.relauncher.CoreModManager;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
 import org.spongepowered.asm.launch.MixinBootstrap;
@@ -16,6 +17,7 @@ import java.util.Map;
 public class UMCMixinPlugin implements IFMLLoadingPlugin {
     public UMCMixinPlugin() {
         MixinBootstrap.init();
+        MixinExtrasBootstrap.init();
         Mixins.addConfiguration("mixins.universalmodcore.json");
 
         CodeSource codeSource = this.getClass().getProtectionDomain().getCodeSource();

--- a/src/main/java/cam72cam/mod/UMCMixinPlugin.java
+++ b/src/main/java/cam72cam/mod/UMCMixinPlugin.java
@@ -2,7 +2,6 @@ package cam72cam.mod;
 
 import net.minecraftforge.fml.relauncher.CoreModManager;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
-import org.apache.logging.log4j.LogManager;
 import org.spongepowered.asm.launch.MixinBootstrap;
 import org.spongepowered.asm.mixin.Mixins;
 
@@ -14,12 +13,11 @@ import java.security.CodeSource;
 import java.util.Map;
 
 @IFMLLoadingPlugin.MCVersion("1.12.2")
-public class UMCMixinLoadingPlugin implements IFMLLoadingPlugin {
-    public UMCMixinLoadingPlugin() {
+public class UMCMixinPlugin implements IFMLLoadingPlugin {
+    public UMCMixinPlugin() {
         MixinBootstrap.init();
         Mixins.addConfiguration("mixins.universalmodcore.json");
 
-        //https://github.com/ReplayMod/ReplayMod/blob/ec50efec104c8345a3a4f20fd44cfb3608cd81bb/src/main/java/com/replaymod/core/LoadingPlugin.java
         CodeSource codeSource = this.getClass().getProtectionDomain().getCodeSource();
         if (codeSource != null) {
             URL location = codeSource.getLocation();
@@ -31,9 +29,6 @@ public class UMCMixinLoadingPlugin implements IFMLLoadingPlugin {
             } catch (URISyntaxException e) {
                 e.printStackTrace();
             }
-        } else {
-            LogManager.getLogger().warn("No CodeSource, if this is not a development environment we might run into problems!");
-            LogManager.getLogger().warn(this.getClass().getProtectionDomain());
         }
     }
 

--- a/src/main/resources/mixins.universalmodcore.json
+++ b/src/main/resources/mixins.universalmodcore.json
@@ -3,7 +3,7 @@
   "package": "cam72cam.mod.mixin",
   "refmap": "mixins.universalmodcore.refmap.json",
   "target": "@env(DEFAULT)",
-  "minVersion": "0.8",
+  "minVersion": "0.7.10",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
   ],

--- a/src/main/resources/mixins.universalmodcore.json
+++ b/src/main/resources/mixins.universalmodcore.json
@@ -1,0 +1,12 @@
+{
+  "required": true,
+  "package": "cam72cam.mod.mixin",
+  "refmap": "mixins.universalmodcore.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+  ],
+  "client": [
+  ]
+}

--- a/src/main/resources/mixins.universalmodcore.json
+++ b/src/main/resources/mixins.universalmodcore.json
@@ -3,7 +3,7 @@
   "package": "cam72cam.mod.mixin",
   "refmap": "mixins.universalmodcore.refmap.json",
   "target": "@env(DEFAULT)",
-  "minVersion": "0.7.10",
+  "minVersion": "0.8.2",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
   ],


### PR DESCRIPTION
This PR adds mixin as UMC dependency to modify minecraft code in an elegant way
Forge below 1.16 doesn't provide this, so we have to add it manually
For further description please refer to #185 

This have no compability issue with other mixin provider mods like MixinBooter

In 1.7.10 we may have to include another mod dependency for UMC to enable mixin0.8