### PR TITLE
[Mainline Feature] Migrate widget definition to lambda

### DIFF
--- a/src/main/java/cam72cam/mod/config/ConfigGui.java
+++ b/src/main/java/cam72cam/mod/config/ConfigGui.java
@@ -27,12 +27,9 @@ public class ConfigGui implements IScreen {
             int finalI = i;
             ConfigFile.ConfigInstance ci = new ConfigFile.ConfigInstance(type);
             ci.read();
-            widgets.add(screen -> new Button(screen, 0 - 100,  finalI * 20, 200, 20, type.getSimpleName()) {
-                @Override
-                public void onClick(Player.Hand hand) {
-                    Minecraft.getMinecraft().displayGuiScreen(new ScreenBuilder(new ConfigGui(ConfigGui.this, ci.pc, ci), () -> true));
-                }
-            });
+            widgets.add(screen -> new Button(screen, 0 - 100,  finalI * 20, 200, 20, type.getSimpleName(), (hand, button) -> {
+                Minecraft.getMinecraft().displayGuiScreen(new ScreenBuilder(new ConfigGui(ConfigGui.this, ci.pc, ci), () -> true));
+            }));
             i++;
         }
     }
@@ -48,18 +45,15 @@ public class ConfigGui implements IScreen {
         };
 
 
-        int i = -1;
+        final int[] i = {-1};
         for (ConfigFile.Property property : pc.properties) {
-            int finalI = i+1;
-            int offsetI = ((i+1) % 8)-1;
+            int finalI = i[0] +1;
+            int offsetI = ((i[0] +1) % 8)-1;
             if (property instanceof ConfigFile.PropertyClass) {
                 widgets.add(screen -> {
-                    Button btn = new Button(screen, 0 - 100, offsetI * 20, 200, 20, property.getName()) {
-                        @Override
-                        public void onClick(Player.Hand hand) {
-                            Minecraft.getMinecraft().displayGuiScreen(new ScreenBuilder(new ConfigGui(ConfigGui.this, (ConfigFile.PropertyClass) property, ci), () -> true));
-                        }
-                    };
+                    Button btn = new Button(screen, 0 - 100, offsetI * 20, 200, 20,
+                                            property.getName(),
+                                            (hand, button) -> Minecraft.getMinecraft().displayGuiScreen(new ScreenBuilder(new ConfigGui(ConfigGui.this, (ConfigFile.PropertyClass) property, ci), () -> true)));
                     onPage.accept(finalI, btn::setVisible);
                     return btn;
                 });
@@ -89,40 +83,34 @@ public class ConfigGui implements IScreen {
                     } else if (prop.field.get(null) instanceof Boolean) {
                         Boolean val = prop.field.getBoolean(null);
                         widgets.add(screen -> {
-                            Button btn = new Button(screen, -1, offsetI * 20, 200, 20, val.toString()) {
-                                @Override
-                                public void onClick(Player.Hand hand) {
-                                    Boolean value = !Boolean.parseBoolean(this.getText());
-                                    this.setText(value.toString());
-                                    try {
-                                        prop.field.setBoolean(null, value);
-                                        ci.write();
-                                    } catch (IllegalAccessException e) {
-                                        e.printStackTrace();
-                                    }
+                            Button btn = new Button(screen, -1, offsetI * 20, 200, 20, val.toString(),(hand, button) -> {
+                                Boolean value = !Boolean.parseBoolean(button.getText());
+                                button.setText(value.toString());
+                                try {
+                                    prop.field.setBoolean(null, value);
+                                    ci.write();
+                                } catch (IllegalAccessException e) {
+                                    e.printStackTrace();
                                 }
-                            };
+                            });
                             onPage.accept(finalI, btn::setVisible);
                             return btn;
                         });
                     } else if (prop.field.getType().isEnum()) {
                         Enum val = (Enum) prop.field.get(null);
                         Enum[] arry = (Enum[]) prop.field.getType().getEnumConstants();
+                        final Enum[] curr = {val};
                         widgets.add(screen -> {
-                            Button btn = new Button(screen, -1, offsetI * 20, 200, 20, val.toString()) {
-                                Enum curr = val;
-                                @Override
-                                public void onClick(Player.Hand hand) {
-                                    curr = arry[(curr.ordinal()+1) % arry.length];
-                                    this.setText(curr.toString());
-                                    try {
-                                        prop.field.set(null, curr);
-                                        ci.write();
-                                    } catch (IllegalAccessException e) {
-                                        e.printStackTrace();
-                                    }
+                            Button btn = new Button(screen, -1, offsetI * 20, 200, 20, val.toString(), (hand, button) -> {
+                                curr[0] = arry[(curr[0].ordinal()+1) % arry.length];
+                                button.setText(curr[0].toString());
+                                try {
+                                    prop.field.set(null, curr[0]);
+                                    ci.write();
+                                } catch (IllegalAccessException e) {
+                                    e.printStackTrace();
                                 }
-                            };
+                            });
                             onPage.accept(finalI, btn::setVisible);
                             return btn;
                         });
@@ -144,18 +132,16 @@ public class ConfigGui implements IScreen {
                                 onPage.accept(finalI, tf::setVisible);
                                 return tf;
                             } else {
-                                Slider s = new Slider(screen, 1, offsetI * 20 + 1, "", range.min(), range.max(), val, true) {
-                                    @Override
-                                    public void onSlider() {
-                                        setText(String.format("%.2f", getValue()));
-                                        try {
-                                            prop.field.set(null, getValue());
-                                            ci.write();
-                                        } catch (IllegalAccessException | NumberFormatException e) {
-                                            ModCore.catching(e);
-                                        }
+                                Slider s = new Slider(screen, 1, offsetI * 20 + 1, "", range.min(), range.max(),
+                                                      val, true, slider -> {
+                                    slider.setText(String.format("%.2f", slider.getValue()));
+                                    try {
+                                        prop.field.set(null, slider.getValue());
+                                        ci.write();
+                                    } catch (IllegalAccessException | NumberFormatException e) {
+                                        ModCore.catching(e);
                                     }
-                                };
+                                });
                                 s.onSlider();
                                 onPage.accept(finalI, s::setVisible);
                                 return s;
@@ -179,18 +165,16 @@ public class ConfigGui implements IScreen {
                                 onPage.accept(finalI, tf::setVisible);
                                 return tf;
                             } else {
-                                Slider s = new Slider(screen, 1, offsetI * 20 + 1, "", range.min(), range.max(), val, false) {
-                                    @Override
-                                    public void onSlider() {
-                                        setText(String.format("%.2f", getValue()));
-                                        try {
-                                            prop.field.set(null, (float)getValue());
-                                            ci.write();
-                                        } catch (IllegalAccessException | NumberFormatException e) {
-                                            ModCore.catching(e);
-                                        }
+                                Slider s = new Slider(screen, 1, offsetI * 20 + 1, "", range.min(), range.max(),
+                                                      val, false, slider -> {
+                                    slider.setText(String.format("%.2f", slider.getValue()));
+                                    try {
+                                        prop.field.set(null, (float)slider.getValue());
+                                        ci.write();
+                                    } catch (IllegalAccessException | NumberFormatException e) {
+                                        ModCore.catching(e);
                                     }
-                                };
+                                });
                                 s.onSlider();
                                 onPage.accept(finalI, s::setVisible);
                                 return s;
@@ -214,18 +198,16 @@ public class ConfigGui implements IScreen {
                                 onPage.accept(finalI, tf::setVisible);
                                 return tf;
                             } else {
-                                Slider s = new Slider(screen, 1, offsetI * 20 + 1, "", range.min(), range.max(), val, true) {
-                                    @Override
-                                    public void onSlider() {
-                                        setText(getValueInt() + "");
-                                        try {
-                                            prop.field.set(null, getValueInt());
-                                            ci.write();
-                                        } catch (IllegalAccessException | NumberFormatException e) {
-                                            ModCore.catching(e);
-                                        }
+                                Slider s = new Slider(screen, 1, offsetI * 20 + 1, "", range.min(), range.max(),
+                                                      val, true, slider -> {
+                                    slider.setText(slider.getValueInt() + "");
+                                    try {
+                                        prop.field.set(null, slider.getValueInt());
+                                        ci.write();
+                                    } catch (IllegalAccessException | NumberFormatException e) {
+                                        ModCore.catching(e);
                                     }
-                                };
+                                });
                                 s.onSlider();
                                 onPage.accept(finalI, s::setVisible);
                                 return s;
@@ -239,35 +221,25 @@ public class ConfigGui implements IScreen {
                     continue;
                 }
                 widgets.add(screen -> {
-                    Button btn = new Button(screen, -200, offsetI * 20, 200, 20, property.getName()) {
-                        @Override
-                        public void onClick(Player.Hand hand) {
-
-                        }
-                    };
+                    Button btn = new Button(screen, -200, offsetI * 20, 200, 20, property.getName(), (hand, button) -> {});
                     btn.setEnabled(false);
                     onPage.accept(finalI, btn::setVisible);
                     return btn;
                 });
             }
 
-            i++;
+            i[0]++;
         }
 
-        int pages = (int) Math.ceil((i+1) / 8.0f);
-        widgets.add(screen -> new Button(screen, 0 - 100,  150, 200, 20, "Page: 1/" + pages) {
-            int i = 0;
-
-            @Override
-            public void onClick(Player.Hand hand) {
-                i++;
-                if (i >= pages) {
-                    i = 0;
-                }
-                this.setText(String.format("Page: %s/%s", i+1, pages));
-                pageEvent.forEach(x -> x.accept(i));
+        int pages = (int) Math.ceil((i[0] +1) / 8.0f);
+        widgets.add(screen -> new Button(screen, 0 - 100,  150, 200, 20, "Page: 1/" + pages, (hand, button) -> {
+            i[0]++;
+            if (i[0] >= pages) {
+                i[0] = 0;
             }
-        });
+            button.setText(String.format("Page: %s/%s", i[0] +1, pages));
+            pageEvent.forEach(x -> x.accept(i[0]));
+        }));
     }
 
     @Override

--- a/src/main/java/cam72cam/mod/gui/screen/Button.java
+++ b/src/main/java/cam72cam/mod/gui/screen/Button.java
@@ -3,39 +3,63 @@ package cam72cam.mod.gui.screen;
 import cam72cam.mod.entity.Player;
 import net.minecraft.client.gui.GuiButton;
 
+import java.util.function.BiConsumer;
+
 /** Base interactable GUI element */
-public abstract class Button {
+public class Button implements IWidget{
+    /**
+     * Handler consumer, called upon clicked
+     * Hand -> PRIMARY is a left-click, SECONDARY is a right-click
+     * Button -> Reference of self, as it may not be fully constructed
+     */
+    protected BiConsumer<Player.Hand, Button> handler;
+
     /** Internal MC obj */
     protected final GuiButton button;
 
     /** Default width/height */
-    public Button(IScreenBuilder builder, int x, int y, String text) {
-        this(builder, x, y, 200, 20, text);
+    public Button(IScreenBuilder builder, int x, int y, String text, BiConsumer<Player.Hand, Button> handler) {
+        this(builder, x, y, 200, 20, text, handler);
     }
 
     /** Custom width/height */
-    public Button(IScreenBuilder builder, int x, int y, int width, int height, String text) {
-        this(builder, new GuiButton(-1, builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, width, height, text));
+    public Button(IScreenBuilder builder, int x, int y, int width, int height, String text, BiConsumer<Player.Hand, Button> handler) {
+        this(builder,
+             new GuiButton(-1, builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, width, height, text),
+             handler);
     }
 
     /** Internal ctr */
-    protected Button(IScreenBuilder builder, GuiButton button) {
+    protected Button(IScreenBuilder builder, GuiButton button, BiConsumer<Player.Hand, Button> handler) {
         this.button = button;
         builder.addButton(this);
+        this.handler = handler;
     }
 
-    /** Currently displayed text */
+    @Override
     public String getText() {
         return button.displayString;
     }
 
-    /** Override current text */
+    @Override
     public void setText(String text) {
         button.displayString = text;
     }
 
-    /** Click handler that must be implemented */
-    public abstract void onClick(Player.Hand hand);
+    @Override
+    public void setVisible(boolean b) {
+        button.visible = b;
+    }
+
+    @Override
+    public void setEnabled(boolean b) {
+        button.enabled = b;
+    }
+
+    /** Internal click handler*/
+    public void onClick(Player.Hand hand) {
+        this.handler.accept(hand, this);
+    }
 
     /** Called every screen draw */
     public void onUpdate() {
@@ -46,16 +70,4 @@ public abstract class Button {
     public void setTextColor(int i) {
         button.packedFGColour = i;
     }
-
-    /** Set the button visible or not */
-    public void setVisible(boolean b) {
-        button.visible = b;
-    }
-
-    /** enable or disable the button */
-    public void setEnabled(boolean b) {
-        button.enabled = b;
-    }
-
-    ;
 }

--- a/src/main/java/cam72cam/mod/gui/screen/Button.java
+++ b/src/main/java/cam72cam/mod/gui/screen/Button.java
@@ -49,13 +49,13 @@ public class Button implements IWidget{
     }
 
     @Override
-    public String getText() {
-        return button.displayString;
+    public void setText(String text) {
+        button.displayString = text;
     }
 
     @Override
-    public void setText(String text) {
-        button.displayString = text;
+    public String getText() {
+        return button.displayString;
     }
 
     @Override
@@ -64,8 +64,18 @@ public class Button implements IWidget{
     }
 
     @Override
+    public boolean isVisible() {
+        return button.visible;
+    }
+
+    @Override
     public void setEnabled(boolean b) {
         button.enabled = b;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return button.enabled;
     }
 
     /** Internal click handler*/

--- a/src/main/java/cam72cam/mod/gui/screen/Button.java
+++ b/src/main/java/cam72cam/mod/gui/screen/Button.java
@@ -22,11 +22,23 @@ public class Button implements IWidget{
         this(builder, x, y, 200, 20, text, handler);
     }
 
+    @Deprecated
+    public Button(IScreenBuilder builder, int x, int y, String text) {
+        this(builder, x, y, 200, 20, text, (hand, button1) -> {});
+    }
+
     /** Custom width/height */
     public Button(IScreenBuilder builder, int x, int y, int width, int height, String text, BiConsumer<Player.Hand, Button> handler) {
         this(builder,
              new GuiButton(-1, builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, width, height, text),
              handler);
+    }
+
+    @Deprecated
+    public Button(IScreenBuilder builder, int x, int y, int width, int height, String text) {
+        this(builder,
+             new GuiButton(-1, builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, width, height, text),
+             (hand, button1) -> {});
     }
 
     /** Internal ctr */

--- a/src/main/java/cam72cam/mod/gui/screen/CheckBox.java
+++ b/src/main/java/cam72cam/mod/gui/screen/CheckBox.java
@@ -1,11 +1,16 @@
 package cam72cam.mod.gui.screen;
 
+import cam72cam.mod.entity.Player;
 import net.minecraftforge.fml.client.config.GuiCheckBox;
 
+import java.util.function.BiConsumer;
+
 /** Basic checkbox */
-public abstract class CheckBox extends Button {
-    public CheckBox(IScreenBuilder builder, int x, int y, String text, boolean enabled) {
-        super(builder, new GuiCheckBox(-1, builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, text, enabled));
+public class CheckBox extends Button {
+    public CheckBox(IScreenBuilder builder, int x, int y, String text, boolean enabled, BiConsumer<Player.Hand, CheckBox> handler) {
+        super(builder,
+              new GuiCheckBox(-1, builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, text, enabled),
+              ((hand, button1) -> handler.accept(hand, (CheckBox) button1)));
     }
 
     public boolean isChecked() {

--- a/src/main/java/cam72cam/mod/gui/screen/CheckBox.java
+++ b/src/main/java/cam72cam/mod/gui/screen/CheckBox.java
@@ -13,6 +13,14 @@ public class CheckBox extends Button {
               ((hand, button1) -> handler.accept(hand, (CheckBox) button1)));
     }
 
+    @Deprecated
+    public CheckBox(IScreenBuilder builder, int x, int y, String text, boolean enabled) {
+        super(builder,
+              new GuiCheckBox(-1, builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, text, enabled),
+              ((hand, button1) -> {}));
+    }
+
+
     public boolean isChecked() {
         return ((GuiCheckBox) this.button).isChecked();
     }

--- a/src/main/java/cam72cam/mod/gui/screen/IScreen.java
+++ b/src/main/java/cam72cam/mod/gui/screen/IScreen.java
@@ -1,13 +1,29 @@
 package cam72cam.mod.gui.screen;
 
+import cam72cam.mod.entity.Player;
+import cam72cam.mod.input.Keyboard;
 import cam72cam.mod.render.opengl.RenderState;
 
 public interface IScreen {
     /** Called when screen is initially constructed */
     void init(IScreenBuilder screen);
 
-    /** Called when enter/return is pressed */
-    void onEnterKey(IScreenBuilder builder);
+    @Deprecated
+    default void onEnterKey(IScreenBuilder builder) { }
+    /** Called when any key is pressed outside textfield */
+    default void onKeyType(IScreenBuilder builder, Keyboard.KeyCode keyCode){
+        if (keyCode == Keyboard.KeyCode.NUMPADENTER || keyCode == Keyboard.KeyCode.RETURN) {
+            onEnterKey(builder);
+        }
+    }
+
+    /**
+     * Called when player click his mouse outside textfield
+     * @param hand PRIMARY -> LMB, SECONDARY -> other buttons
+     * */
+    default void onMouseClick(int x, int y, Player.Hand hand){
+
+    }
 
     /** Called during close */
     void onClose();

--- a/src/main/java/cam72cam/mod/gui/screen/IWidget.java
+++ b/src/main/java/cam72cam/mod/gui/screen/IWidget.java
@@ -1,0 +1,23 @@
+package cam72cam.mod.gui.screen;
+
+public interface IWidget {
+    /**
+     * Change current widget's visibility
+     */
+    void setVisible(boolean visible);
+
+    /**
+     * Enable or disable current widget
+     */
+    void setEnabled(boolean enabled);
+
+    /**
+     * Get current widget's content or display name
+     */
+    String getText();
+
+    /**
+     * Set current widget's content or display name
+     */
+    void setText(String text);
+}

--- a/src/main/java/cam72cam/mod/gui/screen/IWidget.java
+++ b/src/main/java/cam72cam/mod/gui/screen/IWidget.java
@@ -6,10 +6,14 @@ public interface IWidget {
      */
     void setVisible(boolean visible);
 
+    boolean isVisible();
+
     /**
      * Enable or disable current widget
      */
     void setEnabled(boolean enabled);
+
+    boolean isEnabled();
 
     /**
      * Get current widget's content or display name
@@ -20,4 +24,6 @@ public interface IWidget {
      * Set current widget's content or display name
      */
     void setText(String text);
+
+//    void onStateChange();
 }

--- a/src/main/java/cam72cam/mod/gui/screen/ScreenBuilder.java
+++ b/src/main/java/cam72cam/mod/gui/screen/ScreenBuilder.java
@@ -3,6 +3,7 @@ package cam72cam.mod.gui.screen;
 import cam72cam.mod.entity.Player;
 import cam72cam.mod.fluid.Fluid;
 import cam72cam.mod.gui.helpers.GUIHelpers;
+import cam72cam.mod.input.Keyboard;
 import cam72cam.mod.render.opengl.RenderState;
 import cam72cam.mod.resource.Identifier;
 import net.minecraft.client.gui.GuiButton;
@@ -15,6 +16,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+
+import static org.lwjgl.input.Keyboard.getKeyName;
 
 public class ScreenBuilder extends GuiScreen implements IScreenBuilder {
     private final IScreen screen;
@@ -116,26 +119,26 @@ public class ScreenBuilder extends GuiScreen implements IScreenBuilder {
             close();
         }
 
-        // Enter
-        if (keyCode == 28 || keyCode == 156) {
-            screen.onEnterKey(this);
+        if (this.textFields.stream().noneMatch(x -> x.textboxKeyTyped(typedChar, keyCode))) {
+            screen.onKeyType(this , Keyboard.KeyCode.valueOf(getKeyName(keyCode)));
         }
-
-        this.textFields.forEach(x -> x.textboxKeyTyped(typedChar, keyCode));
     }
 
     protected void mouseClicked(int mouseX, int mouseY, int mouseButton) throws IOException {
         // Copy pasta to support right / left button click
+        Player.Hand hand = mouseButton == 0 ? Player.Hand.PRIMARY : Player.Hand.SECONDARY;
 
         for (GuiButton guibutton : this.buttonList) {
             if (guibutton.mousePressed(this.mc, mouseX, mouseY)) {
                 this.selectedButton = guibutton;
                 guibutton.playPressSound(this.mc.getSoundHandler());
-                buttonMap.get(guibutton).onClick(mouseButton == 0 ? Player.Hand.PRIMARY : Player.Hand.SECONDARY);
+                buttonMap.get(guibutton).onClick(hand);
             }
         }
 
-        this.textFields.forEach(x -> x.mouseClicked(mouseX, mouseY, mouseButton));
+        if (this.textFields.stream().noneMatch(x -> x.mouseClicked(mouseX, mouseY, mouseButton))) {
+            screen.onMouseClick(mouseX, mouseY, hand);
+        }
     }
 
     // Default overrides

--- a/src/main/java/cam72cam/mod/gui/screen/ScreenBuilder.java
+++ b/src/main/java/cam72cam/mod/gui/screen/ScreenBuilder.java
@@ -127,9 +127,7 @@ public class ScreenBuilder extends GuiScreen implements IScreenBuilder {
     protected void mouseClicked(int mouseX, int mouseY, int mouseButton) throws IOException {
         // Copy pasta to support right / left button click
 
-        for (int i = 0; i < this.buttonList.size(); ++i) {
-            GuiButton guibutton = super.buttonList.get(i);
-
+        for (GuiButton guibutton : this.buttonList) {
             if (guibutton.mousePressed(this.mc, mouseX, mouseY)) {
                 this.selectedButton = guibutton;
                 guibutton.playPressSound(this.mc.getSoundHandler());

--- a/src/main/java/cam72cam/mod/gui/screen/Slider.java
+++ b/src/main/java/cam72cam/mod/gui/screen/Slider.java
@@ -8,12 +8,17 @@ import java.util.function.Consumer;
 /** Standard slider */
 public class Slider extends Button {
     public Slider(IScreenBuilder builder, int x, int y, String text, double min, double max, double start, boolean doublePrecision, Consumer<Slider> handler) {
+        this(builder, x, y, 150, 20, text, min, max, start, doublePrecision, handler);
+    }
+
+    public Slider(IScreenBuilder builder, int x, int y, int width, int height, String text, double min, double max, double start, boolean doublePrecision, Consumer<Slider> handler) {
         super(builder,
-              new GuiSlider(-1, builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, text, min, max, start, null),
+              new GuiSlider(-1, builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, width, height,
+                            text, "", min, max, start, doublePrecision, true, null),
               ((hand, button1) -> handler.accept((Slider) button1)));
-        ((GuiSlider) this.button).showDecimal = doublePrecision;
         ((GuiSlider) this.button).parent = slider -> Slider.this.onSlider();
     }
+
 
     @Deprecated
     public Slider(IScreenBuilder builder, int x, int y, String text, double min, double max, double start, boolean doublePrecision) {

--- a/src/main/java/cam72cam/mod/gui/screen/Slider.java
+++ b/src/main/java/cam72cam/mod/gui/screen/Slider.java
@@ -34,6 +34,10 @@ public class Slider extends Button {
         this.handler.accept(Player.Hand.PRIMARY, this);
     }
 
+    public void setValue(double value) {
+        ((GuiSlider)button).setValue(value);
+    }
+
     public int getValueInt() {
         return ((GuiSlider) button).getValueInt();
     }

--- a/src/main/java/cam72cam/mod/gui/screen/Slider.java
+++ b/src/main/java/cam72cam/mod/gui/screen/Slider.java
@@ -15,6 +15,15 @@ public class Slider extends Button {
         ((GuiSlider) this.button).parent = slider -> Slider.this.onSlider();
     }
 
+    @Deprecated
+    public Slider(IScreenBuilder builder, int x, int y, String text, double min, double max, double start, boolean doublePrecision) {
+        super(builder,
+              new GuiSlider(-1, builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, text, min, max, start, null),
+              ((hand, button1) -> {}));
+        ((GuiSlider) this.button).showDecimal = doublePrecision;
+        ((GuiSlider) this.button).parent = slider -> Slider.this.onSlider();
+    }
+
     /** Called when the slider value is changed */
     public void onSlider() {
         this.handler.accept(Player.Hand.PRIMARY, this);

--- a/src/main/java/cam72cam/mod/gui/screen/Slider.java
+++ b/src/main/java/cam72cam/mod/gui/screen/Slider.java
@@ -3,22 +3,22 @@ package cam72cam.mod.gui.screen;
 import cam72cam.mod.entity.Player;
 import net.minecraftforge.fml.client.config.GuiSlider;
 
-/** Standard slider */
-public abstract class Slider extends Button {
+import java.util.function.Consumer;
 
-    public Slider(IScreenBuilder builder, int x, int y, String text, double min, double max, double start, boolean doublePrecision) {
-        super(builder, new GuiSlider(-1, builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, text, min, max, start, null));
+/** Standard slider */
+public class Slider extends Button {
+    public Slider(IScreenBuilder builder, int x, int y, String text, double min, double max, double start, boolean doublePrecision, Consumer<Slider> handler) {
+        super(builder,
+              new GuiSlider(-1, builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, text, min, max, start, null),
+              ((hand, button1) -> handler.accept((Slider) button1)));
         ((GuiSlider) this.button).showDecimal = doublePrecision;
         ((GuiSlider) this.button).parent = slider -> Slider.this.onSlider();
     }
 
-    @Override
-    public void onClick(Player.Hand hand) {
-
-    }
-
     /** Called when the slider value is changed */
-    public abstract void onSlider();
+    public void onSlider() {
+        this.handler.accept(Player.Hand.PRIMARY, this);
+    }
 
     public int getValueInt() {
         return ((GuiSlider) button).getValueInt();

--- a/src/main/java/cam72cam/mod/gui/screen/TextField.java
+++ b/src/main/java/cam72cam/mod/gui/screen/TextField.java
@@ -22,13 +22,13 @@ public class TextField implements IWidget{
     }
 
     @Override
-    public String getText() {
-        return textfield.getText();
+    public void setText(String s) {
+        textfield.setText(s);
     }
 
     @Override
-    public void setText(String s) {
-        textfield.setText(s);
+    public String getText() {
+        return textfield.getText();
     }
 
     @Override
@@ -38,8 +38,18 @@ public class TextField implements IWidget{
     }
 
     @Override
+    public boolean isVisible() {
+        return textfield.getVisible();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         textfield.setEnabled(enabled);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return textfield.isEnabled;
     }
 
     /** Validator that can block a string from being entered */

--- a/src/main/java/cam72cam/mod/gui/screen/TextField.java
+++ b/src/main/java/cam72cam/mod/gui/screen/TextField.java
@@ -6,21 +6,40 @@ import net.minecraft.client.gui.GuiTextField;
 import java.util.function.Predicate;
 
 /** Base text field */
-public class TextField {
+public class TextField implements IWidget{
     protected final GuiTextField textfield;
 
     /** Standard constructor */
     public TextField(IScreenBuilder builder, int x, int y, int width, int height) {
-        this(
-                builder,
-                new GuiTextField(-1, Minecraft.getMinecraft().fontRenderer, builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, width, height)
-        );
+        this(builder,
+             new GuiTextField(-1, Minecraft.getMinecraft().fontRenderer, builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, width, height));
     }
 
     /** Internal, can be overridden to support custom GuiTextFields */
     protected TextField(IScreenBuilder builder, GuiTextField internal) {
         this.textfield = internal;
         builder.addTextField(this);
+    }
+
+    @Override
+    public String getText() {
+        return textfield.getText();
+    }
+
+    @Override
+    public void setText(String s) {
+        textfield.setText(s);
+    }
+
+    @Override
+    public void setVisible(boolean visible) {
+        textfield.setVisible(visible);
+        textfield.setEnabled(visible);
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        textfield.setEnabled(enabled);
     }
 
     /** Validator that can block a string from being entered */
@@ -31,21 +50,5 @@ public class TextField {
     /** Move cursor to this text field */
     public void setFocused(boolean b) {
         textfield.setFocused(b);
-    }
-
-    /** Current text */
-    public String getText() {
-        return textfield.getText();
-    }
-
-    /** Overwrite current text */
-    public void setText(String s) {
-        textfield.setText(s);
-    }
-
-    /** Change visibility */
-    public void setVisible(Boolean visible) {
-        textfield.setVisible(visible);
-        textfield.setEnabled(visible);
     }
 }

--- a/src/main/resources/META-INF/UniversalModCore_at.cfg
+++ b/src/main/resources/META-INF/UniversalModCore_at.cfg
@@ -3,3 +3,4 @@ public net.minecraft.client.audio.SoundManager field_148629_h # playingSounds
 public net.minecraft.client.resources.FolderResourcePack func_191385_d(Ljava/lang/String;)Ljava/io/File; # getFile
 public net.minecraft.client.Minecraft field_110449_ao # defaultResourcePacks
 public net.minecraft.client.multiplayer.WorldClient field_73035_a #connection
+public net.minecraft.client.gui.GuiTextField field_146226_p # isEnabled


### PR DESCRIPTION
This PR:
- Changed GUI widgets handler from method override to consumer
- Mark old definition as Deprecated (expected to be removed in UMC 1.3.0)
- Add `IWidget` interface for better organization

To be discussed:
- Should we here shrink down TextField's size by 2 pixels each direction internally to make its border match user's inputted size?
