### PR TITLE
[1.18.2+ Fix] Switch to ForgeSlider

### DIFF
--- a/src/main/java/cam72cam/mod/event/ClientEvents.java
+++ b/src/main/java/cam72cam/mod/event/ClientEvents.java
@@ -12,13 +12,10 @@ import cam72cam.mod.render.GlobalRender;
 import cam72cam.mod.render.opengl.CustomTexture;
 import cam72cam.mod.render.opengl.VBO;
 import cam72cam.mod.world.World;
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.renderer.ShaderInstance;
-import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.world.entity.EntityType;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.*;
@@ -103,7 +100,7 @@ public class ClientEvents {
     public static final Event<Consumer<DrawSelectionEvent.HighlightBlock>> RENDER_MOUSEOVER = new Event<>();
     public static final Event<Consumer<SoundLoadEvent>> SOUND_LOAD = new Event<>();
     public static final Event<Runnable> RELOAD = new Event<>();
-    public static final Event<Consumer<RenderLevelLastEvent>> OPTIFINE_SUCKS = new Event<>();
+//    public static final Event<Consumer<RenderLevelLastEvent>> OPTIFINE_SUCKS = new Event<>();
 
     @Mod.EventBusSubscriber(modid = ModCore.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
     public static class ClientEventBusForge {
@@ -236,10 +233,10 @@ public class ClientEvents {
             SOUND_LOAD.execute(x -> x.accept(event));
         }
 
-        @SubscribeEvent
-        public static void optifineSucksEvent(RenderLevelLastEvent event) {
-            OPTIFINE_SUCKS.execute(x -> x.accept(event));
-        }
+//        @SubscribeEvent
+//        public static void optifineSucksEvent(RenderLevelLastEvent event) {
+//            OPTIFINE_SUCKS.execute(x -> x.accept(event));
+//        }
 
         static boolean hasHacked = false;
         @SubscribeEvent

--- a/src/main/java/cam72cam/mod/event/ClientEvents.java
+++ b/src/main/java/cam72cam/mod/event/ClientEvents.java
@@ -100,7 +100,7 @@ public class ClientEvents {
     public static final Event<Consumer<DrawSelectionEvent.HighlightBlock>> RENDER_MOUSEOVER = new Event<>();
     public static final Event<Consumer<SoundLoadEvent>> SOUND_LOAD = new Event<>();
     public static final Event<Runnable> RELOAD = new Event<>();
-//    public static final Event<Consumer<RenderLevelLastEvent>> OPTIFINE_SUCKS = new Event<>();
+    public static final Event<Consumer<RenderLevelLastEvent>> OPTIFINE_SUCKS = new Event<>();
 
     @Mod.EventBusSubscriber(modid = ModCore.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
     public static class ClientEventBusForge {
@@ -233,10 +233,10 @@ public class ClientEvents {
             SOUND_LOAD.execute(x -> x.accept(event));
         }
 
-//        @SubscribeEvent
-//        public static void optifineSucksEvent(RenderLevelLastEvent event) {
-//            OPTIFINE_SUCKS.execute(x -> x.accept(event));
-//        }
+        @SubscribeEvent
+        public static void optifineSucksEvent(RenderLevelLastEvent event) {
+            OPTIFINE_SUCKS.execute(x -> x.accept(event));
+        }
 
         static boolean hasHacked = false;
         @SubscribeEvent

--- a/src/main/java/cam72cam/mod/gui/helpers/GuiScrollBar.java
+++ b/src/main/java/cam72cam/mod/gui/helpers/GuiScrollBar.java
@@ -1,16 +1,27 @@
 package cam72cam.mod.gui.helpers;
 
-import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.AbstractSliderButton;
 import net.minecraft.network.chat.TextComponent;
-import net.minecraftforge.client.gui.widget.Slider;
+import net.minecraftforge.client.gui.widget.ForgeSlider;
+
+import java.util.function.Consumer;
 
 
 /** Internal scrollbar class */
-class GuiScrollBar extends Slider {
+class GuiScrollBar extends ForgeSlider {
+    private final Consumer<AbstractSliderButton> onPress;
 
-    public GuiScrollBar(int id, int xPos, int yPos, int width, int height, String displayStr, double minVal, double maxVal, double currentVal, Button.OnPress par) {
-        // TODO 1.18.2 ForgeSlider
-        super(xPos, yPos, width, height, new TextComponent(displayStr), new TextComponent(displayStr), minVal, maxVal, currentVal, true, false, par);
+    public GuiScrollBar(int id, int xPos, int yPos, int width, int height, String displayStr,
+                        double minVal, double maxVal, double currentVal, Consumer<AbstractSliderButton> par) {
+        super(xPos, yPos, width, height, new TextComponent(displayStr), new TextComponent(""),
+              minVal, maxVal, currentVal, 0, 4, true);
+        this.onPress = par;
+    }
+
+    @Override
+    protected void applyValue() {
+        super.applyValue();
+        onPress.accept(this);
     }
 
     /* TODO

--- a/src/main/java/cam72cam/mod/gui/screen/Slider.java
+++ b/src/main/java/cam72cam/mod/gui/screen/Slider.java
@@ -41,7 +41,7 @@ public abstract class Slider extends Button {
         super(builder, new InternalForgeSlider(builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, 150, 20,
                                                new TextComponent(text), new TextComponent(""), min, max, start, 0, doublePrecision ? 4 : 0, true));
         ((InternalForgeSlider)this.button).clicker = this::onSlider;
-        ((InternalForgeSlider)this.button).setter = this::getTextSlider;
+        ((InternalForgeSlider)this.button).setter = this::getSliderText;
     }
 
     @Override
@@ -63,9 +63,10 @@ public abstract class Slider extends Button {
     @Override
     public void setText(String text) {
         this.text = text;
+        ((InternalForgeSlider)this.button).updateMessage();
     }
 
-    private String getTextSlider() {
+    private String getSliderText() {
         return this.text;
     }
 }

--- a/src/main/java/cam72cam/mod/gui/screen/Slider.java
+++ b/src/main/java/cam72cam/mod/gui/screen/Slider.java
@@ -1,15 +1,47 @@
 package cam72cam.mod.gui.screen;
 
 import cam72cam.mod.entity.Player;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
+import net.minecraftforge.client.gui.widget.ForgeSlider;
+
+import java.util.function.Supplier;
 
 /** Standard slider */
 public abstract class Slider extends Button {
+    /** Internal wrapper to add onSlider Hook */
+    private static class InternalForgeSlider extends ForgeSlider {
+        private Runnable clicker = () -> {};
+        private Supplier<String> setter = () -> "";
+
+        public InternalForgeSlider(int x, int y, int width, int height, Component prefix, Component suffix, double minValue, double maxValue, double currentValue, double stepSize, int precision, boolean drawString) {
+            super(x, y, width, height, prefix, suffix, minValue, maxValue, currentValue, stepSize, precision, drawString);
+        }
+
+        @Override
+        protected void applyValue() {
+            super.applyValue();
+            clicker.run();
+        }
+
+        @Override
+        protected void updateMessage() {
+            if (setter != null && !setter.get().isEmpty()) {
+                this.setMessage(new TextComponent(setter.get()));
+            } else {
+                super.updateMessage();
+            }
+        }
+    }
+
+    private String text;
 
     public Slider(IScreenBuilder builder, int x, int y, String text, double min, double max, double start, boolean doublePrecision) {
-        super(builder, new net.minecraftforge.client.gui.widget.Slider(builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, new TextComponent(text), min, max, start, b -> {}, null));
-        ((net.minecraftforge.client.gui.widget.Slider) this.button).showDecimal = doublePrecision;
-        ((net.minecraftforge.client.gui.widget.Slider) this.button).parent = slider -> Slider.this.onSlider();
+//        super(builder, new net.minecraftforge.client.gui.widget.Slider(builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, new TextComponent(text), min, max, start, b -> {}, null));
+        super(builder, new InternalForgeSlider(builder.getWidth() / 2 + x, builder.getHeight() / 4 + y, 150, 20,
+                                               new TextComponent(text), new TextComponent(""), min, max, start, 0, doublePrecision ? 4 : 0, true));
+        ((InternalForgeSlider)this.button).clicker = this::onSlider;
+        ((InternalForgeSlider)this.button).setter = this::getTextSlider;
     }
 
     @Override
@@ -21,10 +53,19 @@ public abstract class Slider extends Button {
     public abstract void onSlider();
 
     public int getValueInt() {
-        return ((net.minecraftforge.client.gui.widget.Slider) button).getValueInt();
+        return ((ForgeSlider) button).getValueInt();
     }
 
     public double getValue() {
-        return ((net.minecraftforge.client.gui.widget.Slider) button).getValue();
+        return ((ForgeSlider) button).getValue();
+    }
+
+    @Override
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    private String getTextSlider() {
+        return this.text;
     }
 }


### PR DESCRIPTION
For the removal of `RenderLevelLastEvent`, as 1.17+ IR is incompatible with OptiFine anymore, I think we could safely remove it