### PR TITLE
[Mainline Feature] Force sync for entity floating point fields

### DIFF
--- a/src/main/java/cam72cam/mod/entity/sync/EntitySync.java
+++ b/src/main/java/cam72cam/mod/entity/sync/EntitySync.java
@@ -9,8 +9,9 @@ import cam72cam.mod.serialization.TagField;
 import cam72cam.mod.serialization.TagSerializer;
 import net.minecraft.nbt.NBTBase;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /** TagCompound that auto-serializes an entity's @TagSync fields from server to client */
 public class EntitySync extends TagCompound {
@@ -43,6 +44,20 @@ public class EntitySync extends TagCompound {
         }
 
         TagSerializer.serialize(this, entity, TagSync.class);
+        Set<String> forceUpdates = Arrays.stream(entity.getClass().getDeclaredFields())
+                                         .filter(field -> field.getType().equals(float.class)
+                                                 || field.getType().equals(double.class)
+                                                 || field.getType().equals(Float.class)
+                                                 || field.getType().equals(Double.class))
+                                         .filter(field -> {
+                                             TagSync annotation = field.getAnnotation(TagSync.class);
+                                             if (annotation != null) {
+                                                 return annotation.forceSync();
+                                             }
+                                             return false;
+                                         })
+                                         .map(Field::getName)
+                                         .collect(Collectors.toSet());
 
         TagCompound sync = new TagCompound();
         List<String> removed = new ArrayList<>();
@@ -54,14 +69,16 @@ public class EntitySync extends TagCompound {
                 if (newVal.equals(oldVal)) {
                     continue;
                 }
-                if (oldVal.getId() == 5) {
-                    if (Math.abs(old.internal.getFloat(key) - internal.getFloat(key)) < 0.001) {
-                        continue;
+                if (!forceUpdates.contains(key)) {
+                    if (oldVal.getId() == 5) {
+                        if (Math.abs(old.internal.getFloat(key) - internal.getFloat(key)) < 0.001) {
+                            continue;
+                        }
                     }
-                }
-                if (oldVal.getId() == 6) {
-                    if (Math.abs(old.internal.getDouble(key) - internal.getDouble(key)) < 0.00001) {
-                        continue;
+                    if (oldVal.getId() == 6) {
+                        if (Math.abs(old.internal.getDouble(key) - internal.getDouble(key)) < 0.00001) {
+                            continue;
+                        }
                     }
                 }
             }

--- a/src/main/java/cam72cam/mod/entity/sync/EntitySync.java
+++ b/src/main/java/cam72cam/mod/entity/sync/EntitySync.java
@@ -7,10 +7,10 @@ import cam72cam.mod.serialization.SerializationException;
 import cam72cam.mod.serialization.TagCompound;
 import cam72cam.mod.serialization.TagField;
 import cam72cam.mod.serialization.TagSerializer;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.nbt.NBTBase;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 /** TagCompound that auto-serializes an entity's @TagSync fields from server to client */
 public class EntitySync extends TagCompound {
@@ -19,8 +19,10 @@ public class EntitySync extends TagCompound {
     private int interval;
     // Previous entry (for calculating diff / needs update)
     private TagCompound old;
-    //Cache for TagSync.forceUpdate
-    private static final Map<Class<?>, Set<String>> forceUpdateMapper = new HashMap<>();
+    //Cache for TagSync.floatPrecision and doublePrecision
+    private static final Map<Class<?>, Map<String, Integer>> precisionMapper = new HashMap<>();
+    //lookup table for precisions, 9 is fine
+    private static final double[] syncs = new double[]{1, 0.1, 0.01, 0.001, 0.0001, 0.00001, 0.000001, 0.00000001, 0.000000001};
 
     /** Track properties on entity */
     public EntitySync(CustomEntity entity) {
@@ -45,21 +47,25 @@ public class EntitySync extends TagCompound {
         }
 
         TagSerializer.serialize(this, entity, TagSync.class);
-        Set<String> forceUpdates = forceUpdateMapper.computeIfAbsent(entity.getClass(), clazz ->
+        Map<String, Integer> precision = precisionMapper.computeIfAbsent(entity.getClass(), clazz ->
                 Arrays.stream(clazz.getDeclaredFields())
                       .filter(field -> {
                           TagSync tagSync = field.getAnnotation(TagSync.class);
                           TagField tagField = field.getAnnotation(TagField.class);
-                          if (tagField != null && tagSync != null) {
-                              return tagSync.forceSync();
-                          }
-                          return false;
+                          return tagField != null && tagSync != null;
                       })
-                      .map(field -> {
-                          TagField tagField = field.getAnnotation(TagField.class);
-                          return tagField.value();
-                      })
-                      .collect(Collectors.toSet()));
+                      .collect(Object2IntOpenHashMap::new,
+                               (m, f) -> {
+                                   TagSync tag = f.getAnnotation(TagSync.class);
+                                   Class<?> type = f.getType();
+
+                                   if (type == float.class || type == Float.class) {
+                                       m.put(f.getName(), Math.max(0, Math.min(tag.floatPrecision(), 8)));
+                                   } else if (type == double.class || type == Double.class) {
+                                       m.put(f.getName(), Math.max(0, Math.min(tag.doublePrecision(), 8)));
+                                   }
+                               },
+                               Object2IntOpenHashMap::putAll));
 
         TagCompound sync = new TagCompound();
         List<String> removed = new ArrayList<>();
@@ -71,16 +77,14 @@ public class EntitySync extends TagCompound {
                 if (newVal.equals(oldVal)) {
                     continue;
                 }
-                if (!forceUpdates.contains(key)) {
-                    if (oldVal.getId() == 5) {
-                        if (Math.abs(old.internal.getFloat(key) - internal.getFloat(key)) < 0.001) {
-                            continue;
-                        }
+                if (oldVal.getId() == 5) {
+                    if (Math.abs(old.internal.getFloat(key) - internal.getFloat(key)) < syncs[precision.get(key)]) {
+                        continue;
                     }
-                    if (oldVal.getId() == 6) {
-                        if (Math.abs(old.internal.getDouble(key) - internal.getDouble(key)) < 0.00001) {
-                            continue;
-                        }
+                }
+                if (oldVal.getId() == 6) {
+                    if (Math.abs(old.internal.getDouble(key) - internal.getDouble(key)) < syncs[precision.get(key)]) {
+                        continue;
                     }
                 }
             }
@@ -100,7 +104,7 @@ public class EntitySync extends TagCompound {
             });
         }
 
-        if (sync.internal.getKeySet().size() != 0) {
+        if (!sync.internal.getKeySet().isEmpty()) {
             old = new TagCompound(this.internal.copy());
             new EntitySyncPacket(entity, sync).sendToObserving(entity);
         }

--- a/src/main/java/cam72cam/mod/entity/sync/EntitySync.java
+++ b/src/main/java/cam72cam/mod/entity/sync/EntitySync.java
@@ -9,7 +9,6 @@ import cam72cam.mod.serialization.TagField;
 import cam72cam.mod.serialization.TagSerializer;
 import net.minecraft.nbt.NBTBase;
 
-import java.lang.reflect.Field;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -20,6 +19,8 @@ public class EntitySync extends TagCompound {
     private int interval;
     // Previous entry (for calculating diff / needs update)
     private TagCompound old;
+    //Cache for TagSync.forceUpdate
+    private static final Map<Class<?>, Set<String>> forceUpdateMapper = new HashMap<>();
 
     /** Track properties on entity */
     public EntitySync(CustomEntity entity) {
@@ -44,20 +45,21 @@ public class EntitySync extends TagCompound {
         }
 
         TagSerializer.serialize(this, entity, TagSync.class);
-        Set<String> forceUpdates = Arrays.stream(entity.getClass().getDeclaredFields())
-                                         .filter(field -> field.getType().equals(float.class)
-                                                 || field.getType().equals(double.class)
-                                                 || field.getType().equals(Float.class)
-                                                 || field.getType().equals(Double.class))
-                                         .filter(field -> {
-                                             TagSync annotation = field.getAnnotation(TagSync.class);
-                                             if (annotation != null) {
-                                                 return annotation.forceSync();
-                                             }
-                                             return false;
-                                         })
-                                         .map(Field::getName)
-                                         .collect(Collectors.toSet());
+        Set<String> forceUpdates = forceUpdateMapper.computeIfAbsent(entity.getClass(), clazz ->
+                Arrays.stream(clazz.getDeclaredFields())
+                      .filter(field -> {
+                          TagSync tagSync = field.getAnnotation(TagSync.class);
+                          TagField tagField = field.getAnnotation(TagField.class);
+                          if (tagField != null && tagSync != null) {
+                              return tagSync.forceSync();
+                          }
+                          return false;
+                      })
+                      .map(field -> {
+                          TagField tagField = field.getAnnotation(TagField.class);
+                          return tagField.value();
+                      })
+                      .collect(Collectors.toSet()));
 
         TagCompound sync = new TagCompound();
         List<String> removed = new ArrayList<>();

--- a/src/main/java/cam72cam/mod/entity/sync/TagSync.java
+++ b/src/main/java/cam72cam/mod/entity/sync/TagSync.java
@@ -10,5 +10,8 @@ import java.lang.annotation.RetentionPolicy;
  */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TagSync {
-    boolean forceSync() default true;
+    /**
+     * Should a float change less than 0.001 or a double change less than 0.00001 be synchronized?
+     */
+    boolean forceSync() default false;
 }

--- a/src/main/java/cam72cam/mod/entity/sync/TagSync.java
+++ b/src/main/java/cam72cam/mod/entity/sync/TagSync.java
@@ -11,7 +11,12 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TagSync {
     /**
-     * Should a float change less than 0.001 or a double change less than 0.00001 be synchronized?
+     * Minimum float precision change required for synchronization. Default is 0.001(10 ^ -3), max is 1, min is 10^-8
      */
-    boolean forceSync() default false;
+    int floatPrecision() default 3;
+
+    /**
+     * Minimum double precision change required for synchronization. Default is 0.00001(10 ^ -5), max is 1, min is 10^-8
+     */
+    int doublePrecision() default 5;
 }

--- a/src/main/java/cam72cam/mod/entity/sync/TagSync.java
+++ b/src/main/java/cam72cam/mod/entity/sync/TagSync.java
@@ -10,4 +10,5 @@ import java.lang.annotation.RetentionPolicy;
  */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TagSync {
+    boolean forceSync() default true;
 }


### PR DESCRIPTION
This PR adds a parameter, `forceSync`, for `@TagSync` to enforce updates of floats and doubles with tiny changes.