### PR TITLE
[1.17.1+ Fix] Entity collision and raytrace

### DIFF
--- a/src/main/java/cam72cam/mod/mixin/fix/MixinEntitySectionStorage.java
+++ b/src/main/java/cam72cam/mod/mixin/fix/MixinEntitySectionStorage.java
@@ -1,0 +1,45 @@
+package cam72cam.mod.mixin.fix;
+
+import cam72cam.mod.entity.ModdedEntity;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import net.minecraft.world.level.entity.EntityAccess;
+import net.minecraft.world.level.entity.EntitySection;
+import net.minecraft.world.level.entity.EntitySectionStorage;
+import net.minecraft.world.phys.AABB;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.function.Consumer;
+
+
+/**
+ * Fixes collision detection and ray tracing for entities that span multiple chunks.
+ * <p>
+ * Since Minecraft 1.17, the game only checks for entities within the chunks that the
+ * given bounding box intersects. This causes issues with large entities that extend beyond
+ * their primary chunk, as parts of them in other chunks may be ignored during collision
+ * detection and ray tracing operations.
+ * <p>
+ * This mixin adds a check specifically for our {@link ModdedEntity} instances
+ * to ensure that all relevant entity sections are considered, restoring proper functionality
+ * for large entities that cross chunk boundaries.
+ */
+@Mixin(EntitySectionStorage.class)
+public class MixinEntitySectionStorage<T extends EntityAccess>  {
+    @Shadow
+    @Final
+    private Long2ObjectMap<EntitySection<T>> sections;
+
+    @Inject(method = "forEachAccessibleSection", at = @At("TAIL"))
+    public void inject(AABB pBoundingBox, Consumer<EntitySection<T>> pSection, CallbackInfo ci) {
+        this.sections.values().stream()
+                     .filter(e -> e.getStatus().isAccessible())
+                     .filter(e -> e.getEntities().anyMatch(entity -> entity.getClass().equals(ModdedEntity.class)
+                             && ((ModdedEntity)entity).getBoundingBox().intersects(pBoundingBox)))
+                     .forEach(pSection);
+    }
+}

--- a/src/main/java/cam72cam/mod/mixin/fix/large_entity_collision/MixinEntitySectionStorage.java
+++ b/src/main/java/cam72cam/mod/mixin/fix/large_entity_collision/MixinEntitySectionStorage.java
@@ -1,4 +1,4 @@
-package cam72cam.mod.mixin.fix;
+package cam72cam.mod.mixin.fix.large_entity_collision;
 
 import cam72cam.mod.entity.ModdedEntity;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;

--- a/src/main/java/cam72cam/mod/mixin/fix/large_entity_collision/MixinEntitySectionStorage.java
+++ b/src/main/java/cam72cam/mod/mixin/fix/large_entity_collision/MixinEntitySectionStorage.java
@@ -1,46 +1,19 @@
 package cam72cam.mod.mixin.fix.large_entity_collision;
 
-import cam72cam.mod.entity.ModdedEntity;
-import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import net.minecraft.world.level.entity.EntityAccess;
-import net.minecraft.world.level.entity.EntitySection;
 import net.minecraft.world.level.entity.EntitySectionStorage;
-import net.minecraft.world.phys.AABB;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.function.Consumer;
-
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 /**
- * Fixes collision detection and ray tracing for entities that span multiple chunks.
- * <p>
- * Since Minecraft 1.17, the game only checks for entities within the chunks that the
- * given bounding box intersects. This causes issues with large entities that extend beyond
- * their primary chunk, as parts of them in other chunks may be ignored during collision
- * detection and ray tracing operations.
- * <p>
- * This mixin adds a check specifically for our {@link ModdedEntity} instances
- * to ensure that all relevant entity sections are considered, restoring proper functionality
- * for large entities that cross chunk boundaries.
+ * Re-implement call of <code>Level::getMaxEntityRadius</>
+ * @see cam72cam.mod.ModCore.Internal#commonEvent
  */
 @Mixin(EntitySectionStorage.class)
 public class MixinEntitySectionStorage<T extends EntityAccess>  {
-    @Shadow
-    @Final
-    private Long2ObjectMap<EntitySection<T>> sections;
-
-    @Inject(method = "forEachAccessibleSection", at = @At("TAIL"))
-    public void inject(AABB pBoundingBox, Consumer<EntitySection<T>> pSection, CallbackInfo ci) {
-        this.sections.values().stream()
-                     .filter(e -> e.getStatus().isAccessible())
-                     .filter(e -> e.storage.find(ModdedEntity.class)
-                                                          .stream()
-                                                          .anyMatch(m -> m.getBoundingBox().intersects(pBoundingBox)))
-                     .forEach(pSection);
+    @ModifyConstant(method = "forEachAccessibleSection", constant = @Constant(doubleValue = 2.0))
+    private double increaseMaxEntityRadius(double constant){
+        return 32;
     }
 }

--- a/src/main/java/cam72cam/mod/mixin/fix/large_entity_collision/MixinEntitySectionStorage.java
+++ b/src/main/java/cam72cam/mod/mixin/fix/large_entity_collision/MixinEntitySectionStorage.java
@@ -38,8 +38,9 @@ public class MixinEntitySectionStorage<T extends EntityAccess>  {
     public void inject(AABB pBoundingBox, Consumer<EntitySection<T>> pSection, CallbackInfo ci) {
         this.sections.values().stream()
                      .filter(e -> e.getStatus().isAccessible())
-                     .filter(e -> e.getEntities().anyMatch(entity -> entity.getClass().equals(ModdedEntity.class)
-                             && ((ModdedEntity)entity).getBoundingBox().intersects(pBoundingBox)))
+                     .filter(e -> e.storage.find(ModdedEntity.class)
+                                                          .stream()
+                                                          .anyMatch(m -> m.getBoundingBox().intersects(pBoundingBox)))
                      .forEach(pSection);
     }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -5,3 +5,4 @@ public net.minecraft.server.packs.FolderPackResources m_10281_(Ljava/lang/String
 public net.minecraft.server.level.ChunkMap m_140416_()Ljava/lang/Iterable; # getChunks
 public-f net.minecraft.world.entity.Entity m_142469_()Lnet/minecraft/world/phys/AABB; # net/minecraft/world/entity/Entity/getBoundingBox ()Lnet/minecraft/world/phys/AABB
 public net.minecraft.client.multiplayer.ClientLevel f_104561_ #connection
+public net.minecraft.world.level.entity.EntitySection f_156827_ # storage

--- a/src/main/resources/mixins.universalmodcore.fix.json
+++ b/src/main/resources/mixins.universalmodcore.fix.json
@@ -1,0 +1,19 @@
+{
+  "required": true,
+  "package": "cam72cam.mod.mixin.fix",
+  "refmap": "mixins.universalmodcore.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8.5",
+  "compatibilityLevel": "JAVA_16",
+  "mixins": [
+    "MixinEntitySectionStorage"
+  ],
+  "client": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "overwrites": {
+    "requireAnnotations": true
+  }
+}

--- a/src/main/resources/mixins.universalmodcore.fix.json
+++ b/src/main/resources/mixins.universalmodcore.fix.json
@@ -3,7 +3,7 @@
   "package": "cam72cam.mod.mixin.fix",
   "refmap": "mixins.universalmodcore.refmap.json",
   "target": "@env(DEFAULT)",
-  "minVersion": "0.8.5",
+  "minVersion": "0.8.2",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
     "MixinEntitySectionStorage"

--- a/src/main/resources/mixins.universalmodcore.fix.json
+++ b/src/main/resources/mixins.universalmodcore.fix.json
@@ -6,7 +6,7 @@
   "minVersion": "0.8.2",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
-    "MixinEntitySectionStorage"
+    "large_entity_collision.MixinEntitySectionStorage"
   ],
   "client": [
   ],


### PR DESCRIPTION
Requires #185, so this pr doesn't contain its own build.gradle update

Described in javadoc