### PR TITLE
[1.18.2+ Fix] Entity migration fix

### DIFF
--- a/src/main/java/cam72cam/mod/mixin/fix/entity_data_migration/MixinChunkStorage.java
+++ b/src/main/java/cam72cam/mod/mixin/fix/entity_data_migration/MixinChunkStorage.java
@@ -1,0 +1,55 @@
+package cam72cam.mod.mixin.fix.entity_data_migration;
+
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import com.mojang.datafixers.DataFixer;
+import com.mojang.serialization.Codec;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtUtils;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.datafix.DataFixTypes;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.ChunkGenerator;
+import net.minecraft.world.level.chunk.storage.ChunkStorage;
+import net.minecraft.world.level.storage.DimensionDataStorage;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Fix mojang's DataFixer which deletes our custom entity data in saves updated from 1.16- to 1.18+
+ * <p>
+ * Though we could solve that by letting players update to 1.17 first then 1.18 we'd better handle here
+ */
+@Mixin(ChunkStorage.class)
+public class MixinChunkStorage {
+    @Inject(method = "upgradeChunkTag", at = @At("HEAD"))
+    public void inject1(ResourceKey<Level> p_188289_, Supplier<DimensionDataStorage> p_188290_, CompoundTag p_188291_, Optional<ResourceKey<Codec<? extends ChunkGenerator>>> p_188292_,
+                        CallbackInfoReturnable<CompoundTag> cir, @Share("tag") LocalRef<ListTag> tag) {
+        if(p_188291_.contains("Level")
+           && p_188291_.getCompound("Level").contains("Entities")) {
+            tag.set(p_188291_.getCompound("Level").getList("Entities", CompoundTag.TAG_COMPOUND));
+        }
+    }
+
+    @Redirect(method = "upgradeChunkTag", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NbtUtils;update(Lcom/mojang/datafixers/DataFixer;Lnet/minecraft/util/datafix/DataFixTypes;Lnet/minecraft/nbt/CompoundTag;I)Lnet/minecraft/nbt/CompoundTag;"))
+    public CompoundTag red(DataFixer p_129214_, DataFixTypes p_129215_, CompoundTag p_129216_, int p_129217_, @Share("tag1") LocalRef<CompoundTag> tagLocalRef) {
+        //We want to capture it
+        CompoundTag tag = NbtUtils.update(p_129214_, p_129215_, p_129216_, p_129217_);
+        tagLocalRef.set(tag);
+        return tag;
+    }
+
+    @Inject(method = "upgradeChunkTag", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/nbt/NbtUtils;update(Lcom/mojang/datafixers/DataFixer;Lnet/minecraft/util/datafix/DataFixTypes;Lnet/minecraft/nbt/CompoundTag;I)Lnet/minecraft/nbt/CompoundTag;"))
+    public void inject(ResourceKey<Level> p_188289_, Supplier<DimensionDataStorage> p_188290_, CompoundTag p_188291_, Optional<ResourceKey<Codec<? extends ChunkGenerator>>> p_188292_,
+                       CallbackInfoReturnable<CompoundTag> cir, @Share("tag1") LocalRef<CompoundTag> tagLocalRef, @Share("tag") LocalRef<ListTag> tag) {
+        CompoundTag tag1 = tagLocalRef.get();
+        tag1.put("entities", tag.get());
+    }
+}

--- a/src/main/java/cam72cam/mod/mixin/fix/entity_data_migration/MixinChunkStorage.java
+++ b/src/main/java/cam72cam/mod/mixin/fix/entity_data_migration/MixinChunkStorage.java
@@ -30,8 +30,8 @@ import java.util.function.Supplier;
 @Mixin(ChunkStorage.class)
 public class MixinChunkStorage {
     @Inject(method = "upgradeChunkTag", at = @At("HEAD"))
-    public void inject1(ResourceKey<Level> p_188289_, Supplier<DimensionDataStorage> p_188290_, CompoundTag p_188291_, Optional<ResourceKey<Codec<? extends ChunkGenerator>>> p_188292_,
-                        CallbackInfoReturnable<CompoundTag> cir, @Share("tag") LocalRef<ListTag> tag) {
+    public void captureEntitiesTag(ResourceKey<Level> p_188289_, Supplier<DimensionDataStorage> p_188290_, CompoundTag p_188291_, Optional<ResourceKey<Codec<? extends ChunkGenerator>>> p_188292_,
+                                   CallbackInfoReturnable<CompoundTag> cir, @Share("tag") LocalRef<ListTag> tag) {
         if(p_188291_.contains("Level")
            && p_188291_.getCompound("Level").contains("Entities")) {
             tag.set(p_188291_.getCompound("Level").getList("Entities", CompoundTag.TAG_COMPOUND));
@@ -39,17 +39,10 @@ public class MixinChunkStorage {
     }
 
     @Redirect(method = "upgradeChunkTag", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NbtUtils;update(Lcom/mojang/datafixers/DataFixer;Lnet/minecraft/util/datafix/DataFixTypes;Lnet/minecraft/nbt/CompoundTag;I)Lnet/minecraft/nbt/CompoundTag;"))
-    public CompoundTag red(DataFixer p_129214_, DataFixTypes p_129215_, CompoundTag p_129216_, int p_129217_, @Share("tag1") LocalRef<CompoundTag> tagLocalRef) {
+    public CompoundTag reInject(DataFixer p_129214_, DataFixTypes p_129215_, CompoundTag p_129216_, int p_129217_, @Share("tag") LocalRef<ListTag> tag) {
         //We want to capture it
-        CompoundTag tag = NbtUtils.update(p_129214_, p_129215_, p_129216_, p_129217_);
-        tagLocalRef.set(tag);
-        return tag;
-    }
-
-    @Inject(method = "upgradeChunkTag", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/nbt/NbtUtils;update(Lcom/mojang/datafixers/DataFixer;Lnet/minecraft/util/datafix/DataFixTypes;Lnet/minecraft/nbt/CompoundTag;I)Lnet/minecraft/nbt/CompoundTag;"))
-    public void inject(ResourceKey<Level> p_188289_, Supplier<DimensionDataStorage> p_188290_, CompoundTag p_188291_, Optional<ResourceKey<Codec<? extends ChunkGenerator>>> p_188292_,
-                       CallbackInfoReturnable<CompoundTag> cir, @Share("tag1") LocalRef<CompoundTag> tagLocalRef, @Share("tag") LocalRef<ListTag> tag) {
-        CompoundTag tag1 = tagLocalRef.get();
-        tag1.put("entities", tag.get());
+        CompoundTag compoundTag = NbtUtils.update(p_129214_, p_129215_, p_129216_, p_129217_);
+        compoundTag.put("entities", tag.get());
+        return compoundTag;
     }
 }

--- a/src/main/java/cam72cam/mod/mixin/fix/entity_data_migration/MixinChunkStorage.java
+++ b/src/main/java/cam72cam/mod/mixin/fix/entity_data_migration/MixinChunkStorage.java
@@ -40,9 +40,10 @@ public class MixinChunkStorage {
 
     @Redirect(method = "upgradeChunkTag", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NbtUtils;update(Lcom/mojang/datafixers/DataFixer;Lnet/minecraft/util/datafix/DataFixTypes;Lnet/minecraft/nbt/CompoundTag;I)Lnet/minecraft/nbt/CompoundTag;"))
     public CompoundTag reInject(DataFixer p_129214_, DataFixTypes p_129215_, CompoundTag p_129216_, int p_129217_, @Share("tag") LocalRef<ListTag> tag) {
-        //We want to capture it
         CompoundTag compoundTag = NbtUtils.update(p_129214_, p_129215_, p_129216_, p_129217_);
-        compoundTag.put("entities", tag.get());
+        if (tag.get() != null) {
+            compoundTag.put("entities", tag.get());
+        }
         return compoundTag;
     }
 }

--- a/src/main/resources/mixins.universalmodcore.json
+++ b/src/main/resources/mixins.universalmodcore.json
@@ -1,0 +1,19 @@
+{
+  "required": true,
+  "package": "cam72cam.mod.mixin",
+  "refmap": "mixins.universalmodcore.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.7",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [
+    "fix.entity_data_migration.MixinChunkStorage"
+  ],
+  "client": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "overwrites": {
+    "requireAnnotations": true
+  }
+}


### PR DESCRIPTION
Requires #185 
This PR fixes UMC entity get deleted when opening a save(<= 1.16) in 1.18+, caused by Minecraft's DataFixer