### PR TITLE
[Mainline] Remove support for final fields in TagSerializer

### DIFF
--- a/src/main/java/cam72cam/mod/serialization/TagSerializer.java
+++ b/src/main/java/cam72cam/mod/serialization/TagSerializer.java
@@ -1,6 +1,5 @@
 package cam72cam.mod.serialization;
 
-import cam72cam.mod.ModCore;
 import cam72cam.mod.world.World;
 
 import javax.annotation.Nullable;
@@ -61,7 +60,7 @@ public class TagSerializer {
                     String fieldName = tag.value().isEmpty() ? field.getName() : tag.value();
 
                     if (Modifier.isFinal(field.getModifiers())) {
-                        throw new SerializationException(String.format("A mod is trying to deserialize a tag into a final field %s.  This should never have been implemented.", fieldName));
+                        throw new SerializationException(String.format("A mod is trying to deserialize a tag into a final field %s.%s.  This is not supported.", cls.getName(), field.getName()));
                     }
 
                     TagMapped mapped = field.getType().getAnnotation(TagMapped.class);

--- a/src/main/java/cam72cam/mod/serialization/TagSerializer.java
+++ b/src/main/java/cam72cam/mod/serialization/TagSerializer.java
@@ -61,14 +61,7 @@ public class TagSerializer {
                     String fieldName = tag.value().isEmpty() ? field.getName() : tag.value();
 
                     if (Modifier.isFinal(field.getModifiers())) {
-                        ModCore.warn("A mod is trying to deserialize a tag into a final field %s.  This should never have been implemented and will be removed in future versions.  You have been warned.", fieldName);
-                        try {
-                            Field modifiersField = Field.class.getDeclaredField("modifiers");
-                            modifiersField.setAccessible(true);
-                            modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-                        } catch (NoSuchFieldException | IllegalAccessException e) {
-                            throw new SerializationException(String.format("Unable to access field %s in class %s", fieldName, cls), e);
-                        }
+                        throw new SerializationException(String.format("A mod is trying to deserialize a tag into a final field %s.  This should never have been implemented and will be removed in future versions.  You have been warned.", fieldName));
                     }
 
                     TagMapped mapped = field.getType().getAnnotation(TagMapped.class);

--- a/src/main/java/cam72cam/mod/serialization/TagSerializer.java
+++ b/src/main/java/cam72cam/mod/serialization/TagSerializer.java
@@ -61,7 +61,7 @@ public class TagSerializer {
                     String fieldName = tag.value().isEmpty() ? field.getName() : tag.value();
 
                     if (Modifier.isFinal(field.getModifiers())) {
-                        throw new SerializationException(String.format("A mod is trying to deserialize a tag into a final field %s.  This should never have been implemented and will be removed in future versions.  You have been warned.", fieldName));
+                        throw new SerializationException(String.format("A mod is trying to deserialize a tag into a final field %s.  This should never have been implemented.", fieldName));
                     }
 
                     TagMapped mapped = field.getType().getAnnotation(TagMapped.class);


### PR DESCRIPTION
As for [JEP 500 for Java26](https://openjdk.org/jeps/500), muting final fields via reflection has been prohibited, so I think it's time to finally say goodbye to this non-forward-capable feature

Current system also have bug with Java17 (suspecious for Java11), it would be difficult to remain final support

To be discussed:
- Should we officially add a `Lazy` API to replace those only deserialized once, or keep current status?