### PR TITLE
[Mainline Feature] Add getEntitiesWithinBB in World

### DIFF
--- a/src/main/java/cam72cam/mod/entity/boundingbox/DefaultBoundingBox.java
+++ b/src/main/java/cam72cam/mod/entity/boundingbox/DefaultBoundingBox.java
@@ -5,7 +5,7 @@ import net.minecraft.util.math.AxisAlignedBB;
 
 /** Default implementation of IBoundingBox, do not use directly! */
 public class DefaultBoundingBox implements IBoundingBox {
-    protected final AxisAlignedBB internal;
+    public final AxisAlignedBB internal;
     private Vec3d minCached;
     private Vec3d maxCached;
 

--- a/src/main/java/cam72cam/mod/world/World.java
+++ b/src/main/java/cam72cam/mod/world/World.java
@@ -8,6 +8,7 @@ import cam72cam.mod.block.IBlockTypeBlock;
 import cam72cam.mod.block.tile.TileEntity;
 import cam72cam.mod.entity.*;
 import cam72cam.mod.entity.boundingbox.BoundingBox;
+import cam72cam.mod.entity.boundingbox.DefaultBoundingBox;
 import cam72cam.mod.entity.boundingbox.IBoundingBox;
 import cam72cam.mod.event.ClientEvents;
 import cam72cam.mod.event.CommonEvents;
@@ -27,11 +28,9 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
-import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.math.AxisAlignedBB;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.IPlantable;
@@ -272,6 +271,34 @@ public class World {
             }
         }
         return list;
+    }
+
+    /**
+     * Find UMC Entities which within the BB and are of the given type
+     * <p>
+     * More performant when region is known
+     * */
+    public <T extends Entity> List<T> getEntitiesWithinBB(IBoundingBox bb, Class<T> type) {
+        return getEntitiesWithinBB(bb, (T val) -> true, type);
+    }
+
+    /**
+     * Find UMC Entities which within the BB, match the filter and are of the given type
+     * <p>
+     * More performant when region is known
+     * */
+    public <T extends Entity> List<T> getEntitiesWithinBB(IBoundingBox bb , Predicate<T> filter, Class<T> type) {
+        List<ModdedEntity> entitiesWithinAABB = internal.getEntitiesWithinAABB(ModdedEntity.class,
+                                    bb instanceof DefaultBoundingBox
+                                    ? ((DefaultBoundingBox)bb).internal
+                                    : new AxisAlignedBB(bb.min().internal(), bb.max().internal()));
+
+        return entitiesWithinAABB.stream()
+                                 .map(this::getEntity)
+                                 .filter(type::isInstance)
+                                 .map(type::cast)
+                                 .filter(filter)
+                                 .collect(Collectors.toList());
     }
 
     /** Add a constructed entity to the world */

--- a/src/main/java/cam72cam/mod/world/World.java
+++ b/src/main/java/cam72cam/mod/world/World.java
@@ -288,7 +288,7 @@ public class World {
      * More performant when region is known
      * */
     public <T extends Entity> List<T> getEntitiesWithinBB(IBoundingBox bb , Predicate<T> filter, Class<T> type) {
-        List<ModdedEntity> entitiesWithinAABB = internal.getEntitiesWithinAABB(ModdedEntity.class,
+        List<net.minecraft.entity.Entity> entitiesWithinAABB = internal.getEntitiesWithinAABB(net.minecraft.entity.Entity.class,
                                     bb instanceof DefaultBoundingBox
                                     ? ((DefaultBoundingBox)bb).internal
                                     : new AxisAlignedBB(bb.min().internal(), bb.max().internal()));


### PR DESCRIPTION
This pr adds two methods 
`public <T extends Entity> List<T> getEntitiesWithinBB(IBoundingBox bb, Class<T> type)` 
and 
`public <T extends Entity> List<T> getEntitiesWithinBB(IBoundingBox bb , Predicate<T> filter, Class<T> type)`
to improve performance when trying to get entities within given BB (think hopper)

It would be a disaster to use old `getEntities` which iterates the whole world even if we only want to scan a small space, and I think the cost of converting and casting Minecraft entities again here is reasonable