### PR TITLE
[Breaking Mainline Feature] Add DamageType wrapper

### DIFF
--- a/src/main/java/cam72cam/mod/entity/DamageType.java
+++ b/src/main/java/cam72cam/mod/entity/DamageType.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 /**
  * Damage type wrapper
  * <p>
- * Note that they should be treated as constants and created as soon as possible
+ * Note that in order to make this work on 1.21.1 and upper, <code>DamageType</code>s should be treated as constants and created as soon as possible (like CONSTRUCT phase)
  */
 public class DamageType {
     public static final DamageType FIRE = new DamageType("fire");

--- a/src/main/java/cam72cam/mod/entity/DamageType.java
+++ b/src/main/java/cam72cam/mod/entity/DamageType.java
@@ -1,9 +1,53 @@
 package cam72cam.mod.entity;
 
-public enum DamageType {
-    FIRE,
-    PROJECTILE,
-    EXPLOSION,
-    MAGIC,
-    OTHER,
+import cam72cam.mod.resource.Identifier;
+import net.minecraft.util.DamageSource;
+
+import java.util.HashMap;
+import java.util.Objects;
+
+/**
+ * Damage type wrapper
+ * <p>
+ * Note that they should be treated as constants and created as soon as possible
+ */
+public class DamageType {
+    public static final DamageType FIRE = new DamageType("fire");
+    public static final DamageType PROJECTILE = new DamageType("projectile");
+    public static final DamageType EXPLOSION = new DamageType("explosion");
+    public static final DamageType MAGIC = new DamageType("magic");
+    public static final DamageType OTHER = new DamageType("other");
+
+    private static final HashMap<Identifier, DamageType> registered = new HashMap<>();
+
+    public Identifier damageType;
+    public DamageSource internal;
+
+    public static DamageType getOrCreate(String cause) {
+        return getOrCreate(new Identifier(cause));
+    }
+
+    public static DamageType getOrCreate(Identifier cause) {
+        return registered.computeIfAbsent(cause, DamageType::new);
+    }
+
+    private DamageType(String cause) {
+        this(new Identifier(cause));
+    }
+
+    private DamageType(DamageSource source) {
+        this(new Identifier("minecraft", source.damageType));
+    }
+
+    private DamageType(Identifier cause) {
+        this.damageType = cause;
+        this.internal = new DamageSource(damageType.internal.toString());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        DamageType other = (DamageType) o;
+        return Objects.equals(damageType, other.damageType);
+    }
 }

--- a/src/main/java/cam72cam/mod/entity/Entity.java
+++ b/src/main/java/cam72cam/mod/entity/Entity.java
@@ -225,8 +225,8 @@ public class Entity {
     }
 
     /** Damage entity directly (bypassing armor) */
-    public void directDamage(String msg, double damage) {
-        internal.attackEntityFrom((new DamageSource(msg)).setDamageBypassesArmor(), (float) damage);
+    public void directDamage(DamageType type, double damage) {
+        internal.attackEntityFrom(type.internal.setDamageBypassesArmor(), (float) damage);
     }
 
     protected void createExplosion(Vec3d pos, float size, boolean damageTerrain) {


### PR DESCRIPTION
As of 1.21.1 Mojang moved `DamageType` to data pack registry old way of lazily creating DamageSource from String can no longer be used.

This PR adds registry for that (create them in CONSTRUCT as constant then mixin to actually register in 1.21+)