### PR TITLE
[Mainline Feature] Transient events support

### DIFF
--- a/src/main/java/cam72cam/mod/event/Event.java
+++ b/src/main/java/cam72cam/mod/event/Event.java
@@ -8,31 +8,46 @@ import java.util.function.Function;
 public class Event<T> {
     private final Set<Runnable> pre = new LinkedHashSet<>();
     private final Set<T> callbacks = new LinkedHashSet<>();
+    private final Set<T> flushableCallbacks = new LinkedHashSet<>();
     private final Set<Runnable> post = new LinkedHashSet<>();
 
     public void pre(Runnable callback) {
         pre.add(callback);
     }
+
+    //If this event is fired only 1 time per game launch or should be handled indifferently
     public void subscribe(T callback) {
         callbacks.add(callback);
     }
+
+    //If this event is fired multiple times per game launch and should be handled separately
+    public void subscribeFlushable(T callback) {
+        subscribe(callback);
+        flushableCallbacks.add(callback);
+    }
+
     public void post(Runnable callback) {
         post.add(callback);
     }
+
     void execute(Consumer<T> handler) {
         pre.forEach(Runnable::run);
         callbacks.forEach(handler);
+        callbacks.removeAll(flushableCallbacks);
+
         post.forEach(Runnable::run);
     }
 
     boolean executeCancellable(Function<T, Boolean> handler) {
         pre.forEach(Runnable::run);
-        for (T callback : callbacks) {
+        for (T callback : new LinkedHashSet<>(callbacks)) {
             if (!handler.apply(callback)) {
+                callbacks.removeAll(flushableCallbacks);
                 return false;
             }
         }
         post.forEach(Runnable::run);
+        callbacks.removeAll(flushableCallbacks);
         return true;
     }
 }

--- a/src/main/java/cam72cam/mod/event/Event.java
+++ b/src/main/java/cam72cam/mod/event/Event.java
@@ -6,24 +6,16 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class Event<T> {
-    private final Set<Runnable> pre = new LinkedHashSet<>();
-    private final Set<T> callbacks = new LinkedHashSet<>();
-    private final Set<T> flushableCallbacks = new LinkedHashSet<>();
-    private final Set<Runnable> post = new LinkedHashSet<>();
+    final Set<Runnable> pre = new LinkedHashSet<>();
+    final Set<T> callbacks = new LinkedHashSet<>();
+    final Set<Runnable> post = new LinkedHashSet<>();
 
     public void pre(Runnable callback) {
         pre.add(callback);
     }
 
-    //If this event is fired only 1 time per game launch or should be handled indifferently
     public void subscribe(T callback) {
         callbacks.add(callback);
-    }
-
-    //If this event is fired multiple times per game launch and should be handled separately
-    public void subscribeFlushable(T callback) {
-        subscribe(callback);
-        flushableCallbacks.add(callback);
     }
 
     public void post(Runnable callback) {
@@ -33,21 +25,35 @@ public class Event<T> {
     void execute(Consumer<T> handler) {
         pre.forEach(Runnable::run);
         callbacks.forEach(handler);
-        callbacks.removeAll(flushableCallbacks);
 
         post.forEach(Runnable::run);
     }
 
     boolean executeCancellable(Function<T, Boolean> handler) {
         pre.forEach(Runnable::run);
-        for (T callback : new LinkedHashSet<>(callbacks)) {
+        for (T callback : callbacks) {
             if (!handler.apply(callback)) {
-                callbacks.removeAll(flushableCallbacks);
                 return false;
             }
         }
         post.forEach(Runnable::run);
-        callbacks.removeAll(flushableCallbacks);
         return true;
+    }
+
+    /**
+     * For those events fired multiple times and should be handled respectively
+     */
+    static class TransientEvent<T> extends Event<T> {
+        @Override
+        void execute(Consumer<T> handler) {
+            super.execute(handler);
+            callbacks.clear();
+        }
+
+        boolean executeCancellable(Function<T, Boolean> handler) {
+            boolean result = super.executeCancellable(handler);
+            callbacks.clear();
+            return result;
+        }
     }
 }


### PR DESCRIPTION
This PR adds support for flushable events, which are fired multiple times and should be handled differently each time (consider 1.14+ datapack events in #205, they are fired every time a world loads/manually reload datapacks)