### PR TITLE
[1.20.1] Fix black VBOs on Linux with Embeddium / Oculus

### DIFF
--- a/src/main/java/cam72cam/mod/render/opengl/VBO.java
+++ b/src/main/java/cam72cam/mod/render/opengl/VBO.java
@@ -12,8 +12,8 @@ import com.mojang.blaze3d.vertex.VertexFormatElement;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.ShaderInstance;
-import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.inventory.InventoryMenu;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL32;
 
@@ -177,6 +177,8 @@ public class VBO {
             } else {
                 GL32.glDisableClientState(GL32.GL_NORMAL_ARRAY);
             }*/
+
+            RenderType renderType;
             ShaderInstance shader;
             if (state.stage != null) {
                 shader = switch (state.stage) {
@@ -187,12 +189,22 @@ public class VBO {
                                ? GameRenderer.getRendertypeEntityCutoutShader()
                                : RenderContext.UMC_CORE;
                 };
+
+                renderType = switch (state.stage) {
+                    case GUI -> null;
+                    default -> RenderType.entityCutout(InventoryMenu.BLOCK_ATLAS);
+                };
             } else {
                 shader = GameRenderer.getRendertypeEntityCutoutShader();
+                renderType = RenderType.entityCutout(InventoryMenu.BLOCK_ATLAS);
             }
+
+            if (renderType != null) {
+                renderType.setupRenderState();
+            }
+
             RenderSystem.setShader(() -> shader);
 
-            RenderType.entityCutout(TextureAtlas.LOCATION_BLOCKS).setupRenderState();
             GL32.glBindVertexArray(vao);
             GL32.glBindBuffer(GL32.GL_ARRAY_BUFFER, vbo);
 
@@ -252,7 +264,10 @@ public class VBO {
             this.restore = RenderContext.apply(state, true).and(() -> {
                 RenderContext.checkError();
 
-                RenderType.entityCutout(TextureAtlas.LOCATION_BLOCKS).clearRenderState();
+                if (renderType != null) {
+                    renderType.clearRenderState();
+                }
+
                 shader.getVertexFormat().clearBufferState();
 
                 RenderContext.checkError();

--- a/src/main/java/cam72cam/mod/render/opengl/VBO.java
+++ b/src/main/java/cam72cam/mod/render/opengl/VBO.java
@@ -10,7 +10,9 @@ import com.mojang.blaze3d.vertex.BufferUploader;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormatElement;
 import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.ShaderInstance;
+import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.resources.ResourceLocation;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL32;
@@ -189,6 +191,8 @@ public class VBO {
                 shader = GameRenderer.getRendertypeEntityCutoutShader();
             }
             RenderSystem.setShader(() -> shader);
+
+            RenderType.entityCutout(TextureAtlas.LOCATION_BLOCKS).setupRenderState();
             GL32.glBindVertexArray(vao);
             GL32.glBindBuffer(GL32.GL_ARRAY_BUFFER, vbo);
 
@@ -247,6 +251,8 @@ public class VBO {
 
             this.restore = RenderContext.apply(state, true).and(() -> {
                 RenderContext.checkError();
+
+                RenderType.entityCutout(TextureAtlas.LOCATION_BLOCKS).clearRenderState();
                 shader.getVertexFormat().clearBufferState();
 
                 RenderContext.checkError();


### PR DESCRIPTION
A difference in opengl command order between Windows and Linux was causing the IR rolling stock texture to be loaded into the wrong sampler. This was most noticeable with Embeddium and Oculus enabled, as stock would become completely black. I was able to confirm this wasn't a GPU vendor issue by running Minecraft in WSL with Mesa's llvmpipe software rendering. It was also seen on Nvidia and AMD GPUs. This PR resolves the issue by first initializing the render state using the built-in Entity Cutout RenderType that matches the shader configuration being used.

This may be a deeper issue related to VBO rendering taking place in a separate pass from other entities. This fixes the majority of mods tested, but Distant Horizons seems to still have some issues (especially when used with the LOD Entity Rendering addon). With DH specific stock models turn black, the hotbar has items vanishing when IR stock and normal items are near each other, and the LOD addon causes black boxes around all UMC VBOs. A DH-specific workaround is probably going to be needed for that one, but I haven't looked into it much.

Below is a comparison between the Windows / Linux opengl commands I saved before working on this. The breaking issue was GL_TEXTURE0 being marked as active instead of GL_TEXTURE1.
<details>
<summary>OpenGL Commands</summary>

594     glBindFramebuffer(GL_FRAMEBUFFER, No Resource)
595     glBindFramebuffer(GL_FRAMEBUFFER, Framebuffer 59)
596     glBindTexture(GL_TEXTURE_2D, Texture 226)
597     glTexParameteri(Texture 226, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
598     glTexParameteri(Texture 226, GL_TEXTURE_MAG_FILTER, GL_NEAREST)
**missing 2735 glEnable(GL_DEPTH_TEST)**
599     glBindTexture(GL_TEXTURE_2D, Texture 47)
600     glTexParameteri(Texture 47, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
601     glTexParameteri(Texture 47, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
602     glBindVertexArray(Vertex Array 1655)
603     glBindBuffer(GL_ARRAY_BUFFER, Buffer 1656)
604     glEnableVertexAttribArray(Vertex Array 1655, 0)
605     glVertexAttribPointer(Vertex Array 1655, Buffer 1656, 0, 3, GL_FLOAT, False, 48, 0)
606     glEnableVertexAttribArray(Vertex Array 1655, 1)
607     glVertexAttribPointer(Vertex Array 1655, Buffer 1656, 1, 4, GL_FLOAT, True, 48, 20)
608     glEnableVertexAttribArray(Vertex Array 1655, 2)
609     glVertexAttribPointer(Vertex Array 1655, Buffer 1656, 2, 2, GL_FLOAT, False, 48, 12)
610     glDisableVertexAttribArray(Vertex Array 1655, 3)
611     glVertexAttribI2i(3, { 0, 10, 0, 0 })
612     glDisableVertexAttribArray(Vertex Array 1655, 4)
613     glVertexAttribI2i(4, { 0, 240, 0, 0 })
614     glEnableVertexAttribArray(Vertex Array 1655, 5)
615     glVertexAttribPointer(Vertex Array 1655, Buffer 1656, 5, 3, GL_FLOAT, True, 48, 36)
616     glBindTexture(GL_TEXTURE_2D, Texture 1669)
617     glBindTextureUnit(0, Texture 1669)
618     glVertexAttribI2i(4, { 0, 240, 0, 0 })
619     glDisable(GL_CULL_FACE)
620     glUseProgram(Program 415)
621     glUniform1i(Program 415, { 0 })
**missing 2759 glActiveTexture(GL_TEXTURE0)**
622     glUniform1i(Program 415, { 1 })
623     glActiveTexture(GL_TEXTURE1)
**missing 2762 glBindTexture(GL_TEXTURE_2D, No Resource)**
624     glUniform1i(Program 415, { 2 })
625     glActiveTexture(GL_TEXTURE2)
626     glBindTexture(GL_TEXTURE_2D, Texture 47)
**differs 627     glActiveTexture(GL_TEXTURE0) vs 2766 glActiveTexture(GL_TEXTURE1)**
628     glUniformMatrix4fv(Program 415, False, float[16])
629     glUniformMatrix4fv(Program 415, False, float[16])
630     glUniform4fv(Program 415, { 1.00, 1.00, 1.00, 1.00 })
631     glUniform3fv(Program 415, { 0.09715, 0.95214, -0.28981 })
632     glUniform3fv(Program 415, { -0.09715, 0.57896, 0.80955 })
633     glUniform1fv(Program 415, { 172.80 })
634     glUniform1fv(Program 415, { 192.00 })
635     glUniform4fv(Program 415, { 0.71164, 0.81895, 1.00, 1.00 })
636     glBindTexture(GL_TEXTURE_2D, Texture 1669)
637     glVertexAttribI2i(4, { 0, 240, 0, 0 })
638     glUniform1i(Program 415, { 0 })
**missing 2778 glActiveTexture(GL_TEXTURE0)**
639     glUniform1i(Program 415, { 1 })
640     glActiveTexture(GL_TEXTURE1)
641     glUniform1i(Program 415, { 2 })
642     glActiveTexture(GL_TEXTURE2)
**differs 643     glActiveTexture(GL_TEXTURE0) vs 2783 glActiveTexture(GL_TEXTURE1)**
644     glUniformMatrix4fv(Program 415, False, float[16])
645     glUniformMatrix4fv(Program 415, False, float[16])
646     glUniform4fv(Program 415, { 1.00, 1.00, 1.00, 1.00 })
647     glUniform3fv(Program 415, { 0.09715, 0.95214, -0.28981 })
648     glUniform3fv(Program 415, { -0.09715, 0.57896, 0.80955 })
649     glUniform1fv(Program 415, { 172.80 })
650     glUniform1fv(Program 415, { 192.00 })
651     glUniform4fv(Program 415, { 0.71164, 0.81895, 1.00, 1.00 })
652     glDrawArrays(12582)

</details>