### PR TITLE
[Mainline Feature] Model API rewrite

### DIFF
--- a/src/main/java/cam72cam/mod/model/common/Buffers.java
+++ b/src/main/java/cam72cam/mod/model/common/Buffers.java
@@ -1,0 +1,87 @@
+package cam72cam.mod.model.common;
+
+public class Buffers {
+    public static class FloatBuffer {
+        private int pos;
+        private float[] buffer;
+        public FloatBuffer(int startingSize) {
+            pos = 0;
+            buffer = new float[startingSize];
+        }
+
+        public FloatBuffer add(float f) {
+            if (pos == buffer.length) {
+                float[] newBuffer = new float[buffer.length * 2];
+                System.arraycopy(buffer, 0, newBuffer, 0, buffer.length);
+                buffer = newBuffer;
+            }
+            buffer[pos] = f;
+            pos++;
+            return this;
+        }
+
+        public FloatBuffer add(float a, float b) {
+            return this.add(a).add(b);
+        }
+
+        public FloatBuffer add(float a, float b, float c) {
+            return this.add(a).add(b).add(c);
+        }
+
+        public FloatBuffer add(float a, float b, float c, float d) {
+            return this.add(a).add(b).add(c).add(d);
+        }
+
+        public float[] array() {
+            float[] newBuffer = new float[pos];
+            System.arraycopy(buffer, 0, newBuffer, 0, pos);
+            return newBuffer;
+        }
+
+        public float[] currentArray() {
+            return buffer;
+        }
+
+        public int size() {
+            return pos;
+        }
+    }
+
+    public static class IntBuffer {
+        private int pos;
+        private int[] buffer;
+        public IntBuffer(int startingSize) {
+            pos = 0;
+            buffer = new int[startingSize];
+        }
+
+        public IntBuffer add(int f) {
+            if (pos == buffer.length) {
+                int[] newBuffer = new int[buffer.length * 2];
+                System.arraycopy(buffer, 0, newBuffer, 0, buffer.length);
+                buffer = newBuffer;
+            }
+            buffer[pos] = f;
+            pos++;
+            return this;
+        }
+
+        public IntBuffer add(int a, int b) {
+            return this.add(a).add(b);
+        }
+
+        public IntBuffer add(int a, int b, int c) {
+            return this.add(a).add(b).add(c);
+        }
+
+        public int[] array() {
+            int[] newBuffer = new int[pos];
+            System.arraycopy(buffer, 0, newBuffer, 0, pos);
+            return newBuffer;
+        }
+
+        public int size() {
+            return pos;
+        }
+    }
+}

--- a/src/main/java/cam72cam/mod/model/common/Face.java
+++ b/src/main/java/cam72cam/mod/model/common/Face.java
@@ -1,0 +1,4 @@
+package cam72cam.mod.model.common;
+
+public class Face {
+}

--- a/src/main/java/cam72cam/mod/model/common/Geometry.java
+++ b/src/main/java/cam72cam/mod/model/common/Geometry.java
@@ -1,0 +1,49 @@
+package cam72cam.mod.model.common;
+
+import cam72cam.mod.math.Vec3d;
+import cam72cam.mod.model.common.opengl.VertexBuffer;
+import cam72cam.mod.util.With;
+
+import java.util.List;
+
+public class Geometry {
+    private final VertexAttribute vao;
+    private final VertexBuffer vbo;
+    //TODO optional EBO?
+    private int ebo;
+
+    private boolean isUploaded;
+
+    public Geometry(VertexAttribute vao, VertexBuffer vbo) {
+        this.vao = vao;
+        this.vbo = vbo;
+    }
+
+    public int getFaceCount() {
+        return vbo.getData().length / 3;
+    }
+
+    public List<Vec3d> enumerate() {
+        return null;
+    }
+
+    public void upload() {
+        if (isUploaded) return;
+        synchronized (this) {
+            vbo.upload();
+            isUploaded = true;
+        }
+    }
+
+    public void destroy() {
+        if (!isUploaded) return;
+        synchronized (this) {
+            vbo.close();
+            isUploaded = false;
+        }
+    }
+
+    public With setupRender() {
+        return vao.setup().and(vbo.setup());
+    }
+}

--- a/src/main/java/cam72cam/mod/model/common/Material.java
+++ b/src/main/java/cam72cam/mod/model/common/Material.java
@@ -1,0 +1,37 @@
+package cam72cam.mod.model.common;
+
+import cam72cam.mod.render.opengl.Texture;
+import cam72cam.mod.resource.Identifier;
+
+public class Material {
+    public static final Material UNDEFINED = new Material("undefined", new Identifier(), null, null, new float[]{1, 1, 1, 1});
+
+    public final String name;
+
+    public final Identifier albedo;
+    public final Identifier specular;
+    public final Identifier normal;
+    public final float r;
+    public final float g;
+    public final float b;
+    public final float a;
+
+    public Material(String name, Identifier albedo, Identifier specular, Identifier normal, float[] defaultColor) {
+        this(name, albedo, specular, normal, defaultColor[0], defaultColor[1], defaultColor[2], defaultColor[3]);
+    }
+
+    public Material(String name, Identifier albedo, Identifier specular, Identifier normal, float r, float g, float b, float a) {
+        this.name = name;
+        this.albedo = albedo;
+        this.specular = specular;
+        this.normal = normal;
+        this.r = r;
+        this.g = g;
+        this.b = b;
+        this.a = a;
+    }
+
+    public boolean hasPBR() {
+        return specular != null && normal != null;
+    }
+}

--- a/src/main/java/cam72cam/mod/model/common/Model.java
+++ b/src/main/java/cam72cam/mod/model/common/Model.java
@@ -1,0 +1,41 @@
+package cam72cam.mod.model.common;
+
+import cam72cam.mod.model.obj.FaceAccessor;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+public class Model {
+    private final Geometry geometry;
+    private final Set<Material> materials;
+    private final Map<String, ModelGroup> groups;
+
+    public Model(Geometry geometry, Set<Material> materials) {
+        this(geometry, materials, Collections.singletonMap("model", ModelGroup.fromGeometry(geometry)));
+    }
+
+    public Model(Geometry geometry, Set<Material> materials, Map<String, ModelGroup> groups) {
+        this.geometry = geometry;
+        this.materials = materials;
+        this.groups = groups;
+    }
+
+    public void upload() {
+        geometry.upload();
+//        materials.forEach(Material::upload);
+    }
+
+    public void delete() {
+        geometry.destroy();
+//        materials.forEach(Material::destroy);
+    }
+
+    public void render() {
+        //TODO
+    }
+
+    public Geometry getGeometry() {
+        return geometry;
+    }
+}

--- a/src/main/java/cam72cam/mod/model/common/ModelBuilder.java
+++ b/src/main/java/cam72cam/mod/model/common/ModelBuilder.java
@@ -1,0 +1,133 @@
+package cam72cam.mod.model.common;
+
+import cam72cam.mod.model.common.Buffers.FloatBuffer;
+import cam72cam.mod.model.common.Buffers.IntBuffer;
+import cam72cam.mod.model.common.opengl.VertexBuffer;
+
+import java.util.*;
+
+//TODO datatype other than triangle
+public class ModelBuilder {
+    private final VertexAttribute vertexAttribute;
+
+    private final float[] current = new float[12];
+    private final boolean[] hasProperty = new boolean[12];
+
+    //Internal mapping
+    private static final int pos = 0;
+    private static final int col = 3;
+    private static final int norm = 7;
+    private static final int tex = 10;
+
+    private final FloatBuffer data;           //vertexAttribute.stride floats per vert
+    private final IntBuffer materialsMapping; //1 float per vert
+    private boolean isBuilding;
+    private int verticesCount;
+    private int currentMaterial = 0;
+    private final List<Material> usedMaterials;
+
+    private ModelBuilder(VertexAttribute vertexAttribute) {
+        this.vertexAttribute = vertexAttribute;
+        this.data = new FloatBuffer(1024);
+        this.materialsMapping = new IntBuffer(1024);
+        usedMaterials = new ArrayList<>();
+        usedMaterials.add(Material.UNDEFINED); //Add as 0# element
+    }
+
+    public static ModelBuilder start(VertexAttribute vertexAttribute) {
+        return new ModelBuilder(vertexAttribute);
+    }
+
+    public ModelBuilder addVertex(float x, float y, float z) {
+        if (!isBuilding) {
+            isBuilding = true;
+        }
+
+        Arrays.fill(current, 0);
+        Arrays.fill(hasProperty, false);
+        current[pos] = x;
+        current[pos + 1] = y;
+        current[pos + 2] = z;
+        hasProperty[pos] = true;
+        return this;
+    }
+
+    public ModelBuilder color(float r, float g, float b, float a) {
+        current[col] = r;
+        current[col + 1] = g;
+        current[col + 2] = b;
+        current[col + 3] = a;
+        hasProperty[col] = true;
+        return this;
+    }
+
+    public ModelBuilder normal(float nx, float ny, float nz) {
+        current[norm]  = nx;
+        current[norm + 1] = ny;
+        current[norm + 2] = nz;
+        hasProperty[norm] = true;
+        return this;
+    }
+
+    public ModelBuilder tex(float u, float v) {
+        current[tex] = u;
+        current[tex + 1] = v;
+        hasProperty[tex] = true;
+        return this;
+    }
+
+    public ModelBuilder endVert() {
+        for (VertexAttribute.Elements elements : vertexAttribute.getElements().keySet()) {
+            switch (elements) {
+                case POSITION:
+                    if (!hasProperty[pos]) {
+                        throw new IllegalStateException("Incompleted vertex!");
+                    }
+                    data.add(current[pos], current[pos + 1], current[pos + 2]);
+                    break;
+                case COLOR:
+                    if (!hasProperty[col]) {
+                        throw new IllegalStateException("Incompleted vertex!");
+                    }
+                    data.add(current[col], current[col + 1], current[col + 2], current[col + 3]);
+                    break;
+                case NORMAL:
+                    if (!hasProperty[norm]) {
+                        throw new IllegalStateException("Incompleted vertex!");
+                    }
+                    data.add(current[norm], current[norm + 1], current[norm + 2]);
+                    break;
+                case TEXTURE_UV:
+                    if (!hasProperty[tex]) {
+                        throw new IllegalStateException("Incompleted vertex!");
+                    }
+                    data.add(current[tex], current[tex + 1]);
+                    break;
+            }
+        }
+        materialsMapping.add(currentMaterial);
+
+        if (verticesCount == 2) {
+            isBuilding = false;
+            verticesCount = 0;
+        }
+        return this;
+    }
+
+    public ModelBuilder setMaterial(Material material) {
+        if (isBuilding)
+            throw new IllegalStateException("Cannot set material during building!");
+        if (!usedMaterials.contains(material)) {
+            usedMaterials.add(material);
+        }
+        currentMaterial = usedMaterials.indexOf(material);
+        return this;
+    }
+
+    public Model build() {
+        if(isBuilding)
+            throw new IllegalStateException("Cannot finish Model with unfinished face!");
+        Geometry geom = new Geometry(vertexAttribute, new VertexBuffer(data.array()));
+        return new Model(geom, new HashSet<>(usedMaterials));
+    }
+}

--- a/src/main/java/cam72cam/mod/model/common/ModelGroup.java
+++ b/src/main/java/cam72cam/mod/model/common/ModelGroup.java
@@ -1,0 +1,59 @@
+package cam72cam.mod.model.common;
+
+import cam72cam.mod.math.Vec3d;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ModelGroup {
+    public final String name;
+    public final int faceStart;
+    public final int faceStop;
+    public final Vec3d min;
+    public final Vec3d max;
+    public final Vec3d normal;
+
+    public ModelGroup(String name, int faceStart, int faceStop, Vec3d min, Vec3d max, Vec3d normal) {
+        this.name = name;
+        this.faceStart = faceStart;
+        this.faceStop = faceStop;
+        this.min = min;
+        this.max = max;
+        this.normal = normal;
+    }
+
+    public static ModelGroup fromGeometry(Geometry geometry) {
+        String name = "model";
+        int faceStart = 0;
+        int faceStop = geometry.getFaceCount() - 1;
+
+        List<Vec3d> points = geometry.enumerate();
+        Vec3d first = points.get(0);
+        Vec3d groupMin = points.stream().reduce(first, Vec3d::min);
+        Vec3d groupMax = points.stream().reduce(first, Vec3d::max);
+        Vec3d center = groupMax.add(groupMin).scale(0.5);
+
+        Vec3d min = first;
+        Vec3d max = first;
+        // Furthest from center
+        for (Vec3d point : points) {
+            if (max.distanceToSquared(center) < point.distanceToSquared(center)) {
+                max = point;
+            }
+        }
+        for (Vec3d point : points) {
+            if (min.distanceToSquared(max) < point.distanceToSquared(max)) {
+                min = point;
+            }
+        }
+        Vec3d finalMin = min.lengthSquared() < max.lengthSquared() ? min : max;
+        Vec3d finalMax = min.lengthSquared() < max.lengthSquared() ? max : min;
+        List<Vec3d> minG = points.stream().filter(p -> p.distanceToSquared(finalMin) < p.distanceToSquared(finalMax)).collect(
+                Collectors.toList());
+        List<Vec3d> maxG = points.stream().filter(p -> p.distanceToSquared(finalMin) > p.distanceToSquared(finalMax)).collect(Collectors.toList());
+        Vec3d minN = minG.stream().reduce(Vec3d.ZERO, Vec3d::add).scale(1. / minG.size());
+        Vec3d maxN = maxG.stream().reduce(Vec3d.ZERO, Vec3d::add).scale(1. / maxG.size());
+        Vec3d normal = maxN.subtract(minN).normalize();
+        return new ModelGroup(name, faceStart, faceStop, minN, maxN, normal);
+    }
+}

--- a/src/main/java/cam72cam/mod/model/common/ModelLoader.java
+++ b/src/main/java/cam72cam/mod/model/common/ModelLoader.java
@@ -1,0 +1,34 @@
+package cam72cam.mod.model.common;
+
+import cam72cam.mod.model.common.parser.IModelParser;
+import cam72cam.mod.model.common.parser.OBJParser;
+import cam72cam.mod.model.common.texture.TextureRepacker;
+import cam72cam.mod.resource.Identifier;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.function.Supplier;
+
+public final class ModelLoader {
+    private static final Map<String, Supplier<IModelParser>> PARSERS = new HashMap<>();
+
+    static {
+        registerParser("obj", OBJParser::new);
+    }
+
+    public static void registerParser(String extension, Supplier<IModelParser> factory) {
+        PARSERS.put(extension.toLowerCase(), factory);
+    }
+
+    public static Model load(Identifier location, String ext) throws IOException {
+        return (Model) load(location, ext, Collections.EMPTY_LIST).get(0);
+    }
+
+    public static List<Model> load(Identifier location, String ext, List<String> relativePaths) throws IOException {
+        Supplier<IModelParser> factory = PARSERS.get(ext);
+        if (factory == null) throw new IllegalArgumentException("No parser for ." + ext);
+        IModelParser parser = factory.get();
+        Model baseModel = parser.parse(location);
+        return TextureRepacker.repack(baseModel, relativePaths);
+    }
+}

--- a/src/main/java/cam72cam/mod/model/common/VertexAttribute.java
+++ b/src/main/java/cam72cam/mod/model/common/VertexAttribute.java
@@ -1,0 +1,85 @@
+package cam72cam.mod.model.common;
+
+import cam72cam.mod.util.With;
+import org.lwjgl.opengl.GL11;
+
+import java.util.*;
+
+public class VertexAttribute {
+
+    public static final VertexAttribute POSITION = VertexAttribute.of(Elements.POSITION);
+    public static final VertexAttribute POSITION_COLOR = VertexAttribute.of(Elements.POSITION, Elements.COLOR);
+    public static final VertexAttribute POSITION_UV = VertexAttribute.of(Elements.POSITION, Elements.TEXTURE_UV);
+    public static final VertexAttribute POSITION_NORMAL_UV = VertexAttribute.of(Elements.POSITION, Elements.NORMAL, Elements.TEXTURE_UV);
+    public static final VertexAttribute POSITION_COLOR_UV = VertexAttribute.of(Elements.POSITION, Elements.COLOR, Elements.TEXTURE_UV);
+    public static final VertexAttribute POSITION_COLOR_NORMAL_UV = VertexAttribute.of(Elements.POSITION, Elements.COLOR, Elements.NORMAL, Elements.TEXTURE_UV);
+
+    private final Map<Elements, Integer> elements;
+    private final int stride; //in bytes
+
+    private VertexAttribute(List<Elements> elements) {
+        this.elements = new LinkedHashMap<>();
+        int offset = 0;
+        for (Elements element : elements) {
+            this.elements.put(element, offset);
+            offset += element.size;
+        }
+        this.stride = elements.stream().mapToInt(e -> e.size).sum() * Float.BYTES;
+    }
+
+    public static VertexAttribute of(Elements... elements) {
+        return new VertexAttribute(Arrays.asList(elements));
+    }
+
+    public Map<Elements, Integer> getElements() {
+        return elements;
+    }
+
+    public int getStride() {
+        return stride;
+    }
+
+    public With setup() {
+        GL11.glPushClientAttrib(GL11.GL_CLIENT_VERTEX_ARRAY_BIT);
+        boolean hasNormal = false;
+        for (Map.Entry<Elements, Integer> e : elements.entrySet()) {
+            switch (e.getKey())  {
+                case POSITION:
+                    GL11.glEnableClientState(GL11.GL_VERTEX_ARRAY);
+                    GL11.glVertexPointer(Elements.POSITION.size, GL11.GL_FLOAT, stride, e.getValue() * Float.BYTES);
+                    break;
+                case COLOR:
+                    GL11.glEnableClientState(GL11.GL_COLOR_ARRAY);
+                    GL11.glVertexPointer(Elements.COLOR.size, GL11.GL_FLOAT, stride, e.getValue() * Float.BYTES);
+                    break;
+                case NORMAL:
+                    GL11.glEnableClientState(GL11.GL_NORMAL_ARRAY);
+                    GL11.glVertexPointer(Elements.NORMAL.size, GL11.GL_FLOAT, stride, e.getValue() * Float.BYTES);
+                    hasNormal = true;
+                    break;
+                case TEXTURE_UV:
+                    GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+                    GL11.glVertexPointer(Elements.TEXTURE_UV.size, GL11.GL_FLOAT, stride, e.getValue() * Float.BYTES);
+                    break;
+                default:
+                    //TODO
+            }
+        }
+        if (!hasNormal) {
+            GL11.glDisableClientState(GL11.GL_NORMAL_ARRAY);
+        }
+        return GL11::glPopClientAttrib;
+    }
+
+    public enum Elements {
+        POSITION(3),
+        COLOR(4),
+        NORMAL(3),
+        TEXTURE_UV(2); //Default texture
+
+        public final int size;
+        Elements(int size) {
+            this.size = size;
+        }
+    }
+}

--- a/src/main/java/cam72cam/mod/model/common/opengl/VertexBuffer.java
+++ b/src/main/java/cam72cam/mod/model/common/opengl/VertexBuffer.java
@@ -1,0 +1,56 @@
+package cam72cam.mod.model.common.opengl;
+
+import cam72cam.mod.util.With;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL15;
+
+import java.nio.FloatBuffer;
+
+//Pure VBO without EBO
+public class VertexBuffer {
+    private final float[] data;
+    private int vbo = -1;
+
+    public VertexBuffer(float[] data) {
+        this.data = data;
+    }
+
+    private VertexBuffer(long nativePtr) {
+        //TODO
+        data = null;
+    }
+
+    public int getVbo() {
+        return vbo;
+    }
+
+    public float[] getData() {
+        return data;
+    }
+
+    public void upload() {
+        int oldVbo = GL11.glGetInteger(GL15.GL_ARRAY_BUFFER_BINDING);
+
+        vbo = GL15.glGenBuffers();
+        GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, vbo);
+        GL15.glBufferData(vbo, FloatBuffer.wrap(data), GL15.GL_STATIC_DRAW);
+
+        GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, oldVbo);
+    }
+
+    public void close() {
+        if (vbo != -1) {
+            GL15.glDeleteBuffers(vbo);
+            vbo = -1;
+        }
+    }
+
+    public With setup() {
+        if (vbo == -1) return () -> {};
+        int oldVbo = GL11.glGetInteger(GL15.GL_ARRAY_BUFFER_BINDING);
+        GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, vbo);
+        return () -> {
+            GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, oldVbo);
+        };
+    }
+}

--- a/src/main/java/cam72cam/mod/model/common/parser/IModelParser.java
+++ b/src/main/java/cam72cam/mod/model/common/parser/IModelParser.java
@@ -1,0 +1,10 @@
+package cam72cam.mod.model.common.parser;
+
+import cam72cam.mod.model.common.Model;
+import cam72cam.mod.resource.Identifier;
+
+import java.io.IOException;
+
+public interface IModelParser {
+    Model parse(Identifier location) throws IOException;
+}

--- a/src/main/java/cam72cam/mod/model/common/parser/OBJParser.java
+++ b/src/main/java/cam72cam/mod/model/common/parser/OBJParser.java
@@ -1,0 +1,298 @@
+package cam72cam.mod.model.common.parser;
+
+import cam72cam.mod.math.Vec3d;
+import cam72cam.mod.model.common.*;
+import cam72cam.mod.model.common.opengl.VertexBuffer;
+import cam72cam.mod.resource.Identifier;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class OBJParser implements IModelParser {
+    private Identifier model;
+    private final Buffers.FloatBuffer positions = new Buffers.FloatBuffer(1024);
+    private final Buffers.FloatBuffer normals = new Buffers.FloatBuffer(1024);
+    private final Buffers.FloatBuffer textures = new Buffers.FloatBuffer(1024);
+    // 3 ints per vert, 3 verts per face (v1, vt1, vn1, v2, vt2, vn2, v3, vt3, vn3)
+    private final Buffers.IntBuffer indices = new Buffers.IntBuffer(1024);
+    private final List<String> faceMaterials = new ArrayList<>();
+
+    private final Map<String, Material> materials = new HashMap<>();
+    private final List<ModelGroup> groups = new ArrayList<>();
+    private final Map<String, ModelGroup> correctedGroups = new LinkedHashMap<>();
+    private int currentGroupStart = 0;
+    private String currentGroupName = "defaultName";
+    private boolean hasNormals;
+
+    @Override
+    public Model parse(Identifier location) throws IOException {
+        Material currentMaterial = Material.UNDEFINED;
+        this.model = location;
+        processData();
+
+        float[] position = positions.array();
+        float[] normal = normals.array();
+        float[] texture = textures.array();
+        int[] index = indices.array();
+
+        VertexAttribute attribute = hasNormals ? VertexAttribute.POSITION_COLOR_NORMAL_UV : VertexAttribute.POSITION_COLOR_UV;
+        int stride = attribute.getStride();
+        float[] data = new float[(index.length / 3) * stride];
+
+        //iter indices
+        for (ModelGroup group : groups) {
+            List<Vec3d> points = new ArrayList<>();
+            for (int i = group.faceStart; i <= group.faceStop; i++) {
+                for (int j = 0; j < 3; j++) {
+                    int indicesPtr = i * 9 + j * 3;
+                    int dataPtr = ((i + 1) / 3 + j) * stride;
+                    for (Map.Entry<VertexAttribute.Elements, Integer> e : attribute.getElements().entrySet()) {
+                        switch (e.getKey()) {
+                            case POSITION:
+                                int pos = index[indicesPtr] * 3;
+                                data[dataPtr + e.getValue()] = position[pos];
+                                data[dataPtr + e.getValue() + 1] = position[pos + 1];
+                                data[dataPtr + e.getValue() + 2] = position[pos + 2];
+                                Vec3d vec3d = new Vec3d(position[pos],  position[pos + 1], position[pos + 2]);
+                                points.add(vec3d);
+                                break;
+                            case TEXTURE_UV:
+                                int uv = index[indicesPtr + 1] * 2;
+                                if (uv == -2) {
+                                    data[dataPtr + e.getValue()] = 0;
+                                    data[dataPtr + e.getValue() + 1] = 0;
+                                } else {
+                                    data[dataPtr + e.getValue()] = texture[uv];
+                                    data[dataPtr + e.getValue() + 1] = texture[uv + 1];
+                                }
+                                break;
+                            case NORMAL:
+                                int norm = index[indicesPtr + 2] * 3;
+                                data[dataPtr + e.getValue()] = normal[norm];
+                                data[dataPtr + e.getValue() + 1] = normal[norm + 1];
+                                data[dataPtr + e.getValue() + 2] = normal[norm + 2];
+                                break;
+                            case COLOR:
+                                Material material = materials.get(faceMaterials.get((i + 1) / 9));
+                                data[dataPtr + e.getValue()] = material.r;
+                                data[dataPtr + e.getValue() + 1] = material.g;
+                                data[dataPtr + e.getValue() + 2] = material.b;
+                                data[dataPtr + e.getValue() + 3] = material.a;
+                                break;
+                        }
+                    }
+                }
+            }
+
+            Vec3d first = points.get(0);
+            Vec3d groupMin = points.stream().reduce(first, Vec3d::min);
+            Vec3d groupMax = points.stream().reduce(first, Vec3d::max);
+            Vec3d center = groupMax.add(groupMin).scale(0.5);
+
+            Vec3d min = first;
+            Vec3d max = first;
+            // Furthest from center
+            for (Vec3d point : points) {
+                if (max.distanceToSquared(center) < point.distanceToSquared(center)) {
+                    max = point;
+                }
+            }
+            for (Vec3d point : points) {
+                if (min.distanceToSquared(max) < point.distanceToSquared(max)) {
+                    min = point;
+                }
+            }
+            Vec3d finalMin = min.lengthSquared() < max.lengthSquared() ? min : max;
+            Vec3d finalMax = min.lengthSquared() < max.lengthSquared() ? max : min;
+            List<Vec3d> minG = points.stream().filter(p -> p.distanceToSquared(finalMin) < p.distanceToSquared(finalMax)).collect(
+                    Collectors.toList());
+            List<Vec3d> maxG = points.stream().filter(p -> p.distanceToSquared(finalMin) > p.distanceToSquared(finalMax)).collect(Collectors.toList());
+            Vec3d minN = minG.stream().reduce(Vec3d.ZERO, Vec3d::add).scale(1. / minG.size());
+            Vec3d maxN = maxG.stream().reduce(Vec3d.ZERO, Vec3d::add).scale(1. / maxG.size());
+            Vec3d normalV = maxN.subtract(minN).normalize();
+
+            correctedGroups.put(group.name, new ModelGroup(group.name, group.faceStart, group.faceStop, minN, maxN, normalV));
+        }
+
+        Geometry geometry = new Geometry(attribute, new VertexBuffer(data));
+        return new Model(geometry, new HashSet<>(materials.values()), correctedGroups);
+    }
+
+    private void processData() {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(model.getResourceStream()))) {
+            String line;
+            Material currentMaterial = Material.UNDEFINED;
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith("#") || line.isEmpty()) {
+                    continue;
+                }
+                String[] args = line.split(" ");
+                String cmd = args[0];
+                switch (cmd) {
+                    case "mtllib":
+                        materials.putAll(parseMTL(model.getRelative(args[1])));
+                        break;
+                    case "usemtl":
+                        if (args.length >= 2) {
+                            StringBuilder mtlName = new StringBuilder(args[1]);
+                            for (int i = 2; i < args.length; i++) {
+                                mtlName.append(" ").append(args[i]);
+                            }
+                            currentMaterial = materials.getOrDefault(mtlName.toString(), Material.UNDEFINED);
+                        } else {
+                            currentMaterial = Material.UNDEFINED;
+                        }
+                        break;
+                    case "o":
+                    case "g":
+                        StringBuilder groupName = new StringBuilder(args[1]);
+                        for (int i = 2; i < args.length; i++) {
+                            groupName.append(" ").append(args[i]);
+                        }
+                        addGroup(groupName.toString());
+                        break;
+                    case "v":
+                        positions.add(Float.parseFloat(args[1]), Float.parseFloat(args[2]), Float.parseFloat(args[3]));
+                        break;
+                    case "vn":
+                        normals.add(Float.parseFloat(args[1]), Float.parseFloat(args[2]), Float.parseFloat(args[3]));
+                        break;
+                    case "vt":
+                        textures.add(Float.parseFloat(args[1]), Float.parseFloat(args[2]));
+                        break;
+                    case "f":
+                        if (args.length == 4) {
+                            addFace(args[1], args[2], args[3], currentMaterial.name);
+                        } else if (args.length == 5) {
+                            //TODO
+                            addFace(args[1], args[2], args[3], currentMaterial.name);
+                            addFace(args[3], args[4], args[1], currentMaterial.name);
+                        } else {
+                            for (int i = 2; i < args.length - 1; i++) {
+                                addFace(args[1], args[i], args[i + 1], currentMaterial.name);
+                            }
+                        }
+                        break;
+                    case "l":
+                        // Ignore
+                        // TODO might be able to use this for details
+                        break;
+                    default:
+                        //System.out.println("OBJ: ignored line '" + line + "'");
+                        break;
+                }
+            }
+            addGroup(null); // Finalize last group
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Map<String, Material> parseMTL(Identifier mtl) throws IOException {
+        Map<String, Material> mat = new HashMap<>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(mtl.getResourceStream()))) {
+            String line;
+            String materialName = null;
+            Identifier map_Kd = null;
+            Identifier map_Bump = null;
+            Identifier map_Ns = null;
+            float KdR = 1;
+            float KdG = 1;
+            float KdB = 1;
+            float KdA = 1;
+
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith("#") || line.isEmpty()) {
+                    continue;
+                }
+
+                String[] parts = line.split(" ");
+                switch (parts[0]) {
+                    case "newmtl":
+                        if (materialName != null) {
+                            mat.put(materialName, new Material(materialName, map_Kd, map_Bump, map_Ns, KdR, KdG, KdB, KdA));
+                        }
+                        materialName = parts[1];
+                        for (int i = 2; i < parts.length; i++) {
+                            materialName += " " + parts[i];
+                        }
+                        map_Kd = null;
+                        map_Ns = null;
+                        map_Bump = null;
+                        KdR = 1;
+                        KdG = 1;
+                        KdB = 1;
+                        KdA = 1;
+                        break;
+                    case "Ka":
+                        break;
+                    case "Kd":
+                        KdR = Float.parseFloat(parts[1]);
+                        KdG = Float.parseFloat(parts[2]);
+                        KdB = Float.parseFloat(parts[3]);
+                        if (parts.length > 4) {
+                            KdA = Float.parseFloat(parts[4]);
+                        } else {
+                            KdA = 1.0f;
+                        }
+                        break;
+                    case "Ks":
+                        break;
+                    case "map_Kd":
+                        map_Kd = mtl.getRelative(parts[1]);
+                        break;
+                    case "map_Bump":
+                        map_Bump = mtl.getRelative(parts[1]);
+                        break;
+                    case "map_Ns":
+                        map_Ns = mtl.getRelative(parts[1]);
+                        break;
+                    case "Ns":
+                    case "Ke":
+                    case "Ni":
+                    case "d":
+                    case "illum":
+                    default:
+                        break;
+                }
+            }
+            if (materialName != null) {
+                mat.put(materialName, new Material(materialName, map_Kd, map_Bump, map_Ns, KdR, KdG, KdB, KdA));
+            }
+            return mat;
+        }
+    }
+
+    private void addFace(String a, String b, String c, String material) {
+        parsePoint(a);
+        parsePoint(b);
+        parsePoint(c);
+        faceMaterials.add(material);
+    }
+
+    private void addGroup(String name) {
+        if (currentGroupStart != faceMaterials.size()) {
+            groups.add(new ModelGroup(currentGroupName, currentGroupStart, faceMaterials.size() - 1, null, null, null));
+        }
+        currentGroupName = name;
+        currentGroupStart = faceMaterials.size();
+    }
+
+    private void parsePoint(String point) {
+        String[] sp = point.split("/");
+        for (int i = 0; i < 3; i++) {
+            if (i < sp.length && !sp[i].isEmpty()) {
+                indices.add(Integer.parseInt(sp[i]) - 1);
+            } else {
+                indices.add(-1);
+                if (i == 2) {
+                    //VN
+                    this.hasNormals = false;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/cam72cam/mod/model/common/texture/TextureRepacker.java
+++ b/src/main/java/cam72cam/mod/model/common/texture/TextureRepacker.java
@@ -1,0 +1,362 @@
+package cam72cam.mod.model.common.texture;
+
+import cam72cam.mod.Config;
+import cam72cam.mod.ModCore;
+import cam72cam.mod.model.common.Model;
+import cam72cam.mod.model.obj.ImageUtils;
+import cam72cam.mod.model.obj.Material;
+import cam72cam.mod.resource.Identifier;
+import org.apache.commons.lang3.tuple.Pair;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static cam72cam.mod.model.obj.ImageUtils.scaleImage;
+
+/* primer: https://codeincomplete.com/articles/bin-packing/ */
+public class TextureRepacker {
+    private int width = 0;
+    private int height = 0;
+    private int scaledWidth = 0;
+    private int scaledHeight = 0;
+    private Function<String, Identifier> paths;
+    private Function<String, InputStream> lookup;
+
+    public final Map<String, UVConverter> converters = new HashMap<>();
+    public final Map<String, Supplier<BufferedImage>> textures = new HashMap<>();
+    public final Map<String, Supplier<BufferedImage>> normals = new HashMap<>();
+    public final Map<String, Supplier<BufferedImage>> speculars = new HashMap<>();
+
+    private final Map<String, BufferedImage> imageCache = new HashMap<>();
+
+    public static List<Model> repack(Model base, List<String> variants) {
+
+    }
+
+    private BufferedImage getCachedImage(String origPath, String variant) {
+        if (variant != null && !variant.isEmpty()) {
+            try {
+                // Variants should only be read once
+                String path = origPath;
+                String[] sp = path.split("/");
+                String fname = sp[sp.length - 1];
+                path = path.replaceAll(fname, variant + "/" + fname);
+                return ImageIO.read(lookup.apply(path));
+            } catch (Exception e) {
+                //Fallback
+                return getCachedImage(origPath, null);
+            }
+        }
+
+        // Base image should be cached and re-used when applicable
+        return imageCache.computeIfAbsent(origPath, path -> {
+            try {
+                return ImageIO.read(lookup.apply(origPath));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    class Node {
+        Dimension size;
+        List<Material> materials;
+        Material texture;
+        int width;
+        int height;
+        Node down;
+        Node right;
+
+        public Node(List<Material> materials) {
+            this.materials = materials;
+            this.width = this.height = 32;
+            this.texture = null; // Textured images will be color only if the image fails to load.
+
+            size = new Dimension(width, height);
+
+            if (materials.get(0).hasTexture()) {
+                try {
+                    BufferedImage image = getCachedImage(materials.get(0).texKd, null);
+                    size = new Dimension(image.getWidth(), image.getHeight());
+                    this.width = materials.stream().mapToInt(x -> x.copiesU).max().getAsInt() * size.width;
+                    this.height = materials.stream().mapToInt(x -> x.copiesV).max().getAsInt() * size.height;
+                    this.texture = materials.get(0);
+                } catch (Exception e) {
+                    ModCore.catching(e, "Unable to load image %s", paths.apply(materials.get(0).texKd));
+                }
+            }
+        }
+
+        public Node(int width, int height) {
+            this.width = width;
+            this.height = height;
+            materials = null;
+        }
+
+        private boolean canFit(Node node) {
+            return materials == null && this.width >= node.width && this.height >= node.height;
+        }
+
+        public boolean addNode(Node node) {
+            if (this.right != null) {
+                if (this.right.canFit(node)) {
+                    node.right = new Node(this.right.width - node.width, this.right.height);
+                    node.down = new Node(node.width, this.right.height - node.height);
+                    node.right = node.right.width == 0 ? null : node.right;
+                    node.down = node.down.height == 0 ? null : node.down;
+                    this.right = node;
+                    return true;
+                } else {
+                    boolean recursed = this.right.addNode(node);
+                    if (recursed) {
+                        return true;
+                    }
+                }
+            }
+            if (this.down != null) {
+                if (this.down.canFit(node)) {
+                    node.right = new Node(this.down.width - node.width, node.height);
+                    node.down = new Node(this.down.width, this.down.height - node.height);
+                    node.right = node.right.width == 0 ? null : node.right;
+                    node.down = node.down.height == 0 ? null : node.down;
+                    this.down = node;
+                    return true;
+                } else {
+                    boolean recursed = this.down.addNode(node);
+                    if (recursed) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        public int getFullWidth() {
+            return width + (this.right != null ? this.right.getFullWidth() : 0);
+        }
+        public int getFullHeight() {
+            return height + (this.down != null ? this.down.getFullHeight() : 0);
+        }
+
+        public Node getFurthestRight() {
+            return right != null ? right.getFurthestRight() : this;
+        }
+
+        public Node getFurthestDown() {
+            return down != null ? down.getFurthestDown() : this;
+        }
+
+        public void converters(int x, int y) {
+            if (materials != null) {
+                int copiesU = materials.stream().mapToInt(m -> m.copiesU).max().getAsInt();
+                int copiesV = materials.stream().mapToInt(m -> m.copiesV).max().getAsInt();
+                UVConverter converter = new UVConverter(
+                        x, y,
+                        size.width, size.height,
+                        copiesU, copiesV,
+                        TextureRepacker.this.width, TextureRepacker.this.height
+                );
+                for (Material material : materials) {
+                    converters.put(material.name, converter);
+                }
+                if (right != null) {
+                    right.converters(x + width, y);
+                }
+                if (down != null) {
+                    down.converters(x, y + height);
+                }
+            }
+        }
+
+        public void draw(int x, int y, String variant, Graphics2D graphics, Function<Material, String> texlu) {
+            if (materials == null) {
+                graphics.setColor(Color.BLACK);
+                graphics.fillRect(x, y, width, height);
+                return;
+            }
+
+            BufferedImage image;
+            if (texture != null) {
+                String origPath = texlu.apply(texture);
+                image = getCachedImage(origPath, variant);
+            } else {
+                Material mat = materials.get(0);
+                int r = (int) (Math.max(0, mat.KdR) * 255);
+                int g = (int) (Math.max(0, mat.KdG) * 255);
+                int b = (int) (Math.max(0, mat.KdB) * 255);
+                int a = (int) (mat.KdA * 255);
+                int cint = (a << 24) | (r << 16) | (g << 8) | b;
+                image = new BufferedImage(this.width, this.height, BufferedImage.TYPE_INT_ARGB);
+                for (int px = 0; px < this.width; px++) {
+                    for (int py = 0; py < this.height; py++) {
+                        image.setRGB(px, py, cint);
+                    }
+                }
+            }
+
+            int copiesU = materials.stream().mapToInt(m -> m.copiesU).max().getAsInt();
+            int copiesV = materials.stream().mapToInt(m -> m.copiesV).max().getAsInt();
+
+            for (int cU = 0; cU < copiesU; cU++) {
+                for (int cV = 0; cV < copiesV; cV++) {
+                    int offX = x + image.getWidth() * cU;
+                    int offY = y + image.getHeight() * cV;
+                    graphics.drawImage(image, null, offX, offY);
+                }
+            }
+            if (right != null) {
+                right.draw(x + width, y, variant, graphics, texlu);
+            }
+            if (down != null) {
+                down.draw(x, y + height, variant, graphics, texlu);
+            }
+        }
+    }
+
+    public static class UVConverter {
+        private final int x;
+        private final int y;
+        private final int width;
+        private final int height;
+        private final int copiesU;
+        private final int copiesV;
+        private final int sheetWidth;
+        private final int sheetHeight;
+
+        public UVConverter(int x, int y, int width, int height, int copiesU, int copiesV, int sheetWidth, int sheetHeight) {
+            this.x = x;
+            this.y = y;
+            this.width = width;
+            this.height = height;
+            this.copiesU = copiesU;
+            this.copiesV = copiesV;
+            this.sheetWidth = sheetWidth;
+            this.sheetHeight = sheetHeight;
+        }
+
+        public float convertU(float u) {
+            float originU = x / (float) sheetWidth;
+            float offsetU = u * (float) this.width / sheetWidth;
+            return originU + offsetU;
+        }
+
+        public float convertV(float v) {
+            float originV = 1 - ((y+height*copiesV) / (float) sheetHeight);
+            float offsetV = v * ((float) this.height / sheetHeight);
+            return 1-(originV + offsetV);
+        }
+    }
+
+    public TextureRepacker(Identifier ident, Function<String, Identifier> paths, Function<String, InputStream> lookup, Collection<Material> materials, Collection<String> variants) {
+        ImageIO.setUseCache(false);
+        if (materials.isEmpty()) {
+            return;
+        }
+
+        this.paths = paths;
+        this.lookup = lookup;
+
+        List<Node> inputNodes = materials.stream()
+                .filter(m -> m.used)
+                .collect(Collectors.groupingBy(k -> k.texKd == null ? k.name : k.texKd)).values().stream()
+                .map(Node::new)
+                .sorted(Comparator.comparingInt(x -> -10000 * x.height + x.width))
+                .collect(Collectors.toList());
+
+        Node rootNode = inputNodes.remove(0);
+        for (Node node : inputNodes) {
+            if (!rootNode.addNode(node)) {
+                boolean fitsRight = rootNode.getFullHeight() >= node.height;
+                boolean fitsDown = rootNode.getFullWidth() >= node.width;
+                boolean betterFitRight = rootNode.getFullWidth() + node.width < rootNode.getFullHeight() + node.height;
+                if (fitsRight && (!fitsDown || betterFitRight)) {
+                    // Expand right
+                    rootNode.getFurthestRight().right = new Node(node.width, rootNode.getFullHeight());
+                } else if (fitsDown) {
+                    // Expand down
+                    rootNode.getFurthestDown().down = new Node(rootNode.getFullWidth(), node.height);
+                } else {
+                    throw new RuntimeException("Impossible!!!!");
+                }
+                rootNode.addNode(node);
+            }
+        }
+
+        this.width = rootNode.getFullWidth();
+        this.height = rootNode.getFullHeight();
+        if (needsScaling()) {
+            Pair<Integer, Integer> size = ImageUtils.scaleSize(width, height, Config.getMaxTextureSize());
+            this.scaledWidth = size.getLeft();
+            this.scaledHeight = size.getRight();
+        } else {
+            this.scaledWidth = width;
+            this.scaledHeight = height;
+        }
+        rootNode.converters(0, 0);
+
+        for (String variant : variants) {
+            textures.put(variant, () -> {
+                BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+                Graphics2D graphics = image.createGraphics();
+                rootNode.draw(0, 0, variant, graphics, m -> m.texKd);
+                if (needsScaling()) {
+                    int originalWidth = image.getWidth();
+                    int originalHeight = image.getHeight();
+                    image = scaleImage(image, Config.getMaxTextureSize());
+                    ModCore.warn("Scaling texture '%s' for %s from (%s x %s) to (%s x %s)", variant, ident, originalWidth, originalHeight, image.getWidth(), image.getHeight());
+                }
+                return image;
+            });
+
+            if (materials.stream().anyMatch(x -> x.texBump != null)) {
+                normals.put(variant, () -> {
+                    BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+                    Graphics2D graphics = image.createGraphics();
+                    rootNode.draw(0, 0, variant, graphics, m -> m.texBump);
+                    if (needsScaling()) {
+                        int originalWidth = image.getWidth();
+                        int originalHeight = image.getHeight();
+                        image = scaleImage(image, Config.getMaxTextureSize());
+                        ModCore.warn("Scaling texture '%s' for %s from (%s x %s) to (%s x %s)", variant, ident, originalWidth, originalHeight, image.getWidth(), image.getHeight());
+                    }
+                    return image;
+                });
+            }
+
+            if (materials.stream().anyMatch(x -> x.texNs != null)) {
+                speculars.put(variant, () -> {
+                    BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+                    Graphics2D graphics = image.createGraphics();
+                    rootNode.draw(0, 0, variant, graphics, m -> m.texNs);
+                    if (needsScaling()) {
+                        int originalWidth = image.getWidth();
+                        int originalHeight = image.getHeight();
+                        image = scaleImage(image, Config.getMaxTextureSize());
+                        ModCore.warn("Scaling texture '%s' for %s from (%s x %s) to (%s x %s)", variant, ident, originalWidth, originalHeight, image.getWidth(), image.getHeight());
+                    }
+                    return image;
+                });
+            }
+        }
+        imageCache.clear();
+    }
+
+    private boolean needsScaling() {
+        return width > Config.getMaxTextureSize() || height > Config.getMaxTextureSize();
+    }
+
+    public int getWidth() {
+        return scaledWidth;
+    }
+    public int getHeight() {
+        return scaledHeight;
+    }
+}


### PR DESCRIPTION
This is a WIP PR aiming at improving the extensibility of existing `OBJModel` system, and abstract OpenGL stuffs out in preparation for Vulkan in the near future

This PR should standalone with current `OBJModel` system thus old code will work, but it's expected to remove old system once the new one is stable enough

This PR: 
- Added `ModelLoader` as new API entry point
- Added `ModelBuilder` for dynamic model generation, inspird by vanilla `BufferBuilder` and aims at replacing `DirectDraw`
- Added `IModelParser` for supporting more model formats
- Separated `Geometry` and `Material` data

TODOs:
- Port texture repacking from `OBJTexturePacker` and other existing features
- Refactor cache structure, we could save metadata in json and have a dedicated data class
- TBD