### PR TITLE
[Mainline Feature] Add BuiltinPack for in-code resource modifying

### DIFF
--- a/src/main/java/cam72cam/mod/ModCore.java
+++ b/src/main/java/cam72cam/mod/ModCore.java
@@ -167,7 +167,7 @@ public class ModCore {
         public void event(ModEvent event, Mod m) {
             if (event == ModEvent.CONSTRUCT) {
                 Config.getMaxTextureSize(); //populate
-                BuiltinPacks.loadResource(m);
+                BuiltinPacks.loadModResource(m);
             }
             super.event(event, m);
             m.clientEvent(event);

--- a/src/main/java/cam72cam/mod/ModCore.java
+++ b/src/main/java/cam72cam/mod/ModCore.java
@@ -185,7 +185,7 @@ public class ModCore {
                     // Force first and last (and inject mod time) BUG: sounds can still be overridden by resource packs
                     packs.add(1, modPack);
                     packs.add(modPack);
-                    BuiltinPack.loadWrappedResource(packs);
+                    BuiltinPack.loadUMCResource(packs);
 
                     constructed = true;
                 }

--- a/src/main/java/cam72cam/mod/ModCore.java
+++ b/src/main/java/cam72cam/mod/ModCore.java
@@ -17,6 +17,7 @@ import cam72cam.mod.util.MinecraftFiles;
 import cam72cam.mod.util.ModCoreCommand;
 import cam72cam.mod.world.ChunkManager;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.IResourcePack;
 import net.minecraft.client.resources.SimpleReloadableResourceManager;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod.EventHandler;
@@ -142,6 +143,10 @@ public class ModCore {
         return proxy.getGPUTextureSize();
     }
 
+    public List<Mod> getLoadedMods() {
+        return mods;
+    }
+
     @SidedProxy(serverSide = "cam72cam.mod.ModCore$ServerProxy", clientSide = "cam72cam.mod.ModCore$ClientProxy", modId = ModCore.MODID)
     private static Proxy proxy;
     /** Hooked into forge's proxy system and fires off corresponding events */
@@ -164,10 +169,26 @@ public class ModCore {
     }
 
     public static class ClientProxy extends Proxy {
+        private static boolean constructed = false;
+
         public void event(ModEvent event, Mod m) {
             if (event == ModEvent.CONSTRUCT) {
                 Config.getMaxTextureSize(); //populate
-                BuiltinPacks.loadModResource(m);
+
+                if (!constructed) {
+                    for (Mod mod : instance.mods) {
+                        BuiltinPacks.loadModResource(mod);
+                    }
+
+                    List<IResourcePack> packs = Minecraft.getMinecraft().defaultResourcePacks;
+                    IResourcePack modPack = BuiltinPacks.attach(Loader.instance().activeModContainer().getSource());
+                    // Force first and last (and inject mod time) BUG: sounds can still be overridden by resource packs
+                    packs.add(1, modPack);
+                    packs.add(modPack);
+                    BuiltinPacks.loadWrappedResource(packs);
+
+                    constructed = true;
+                }
             }
             super.event(event, m);
             m.clientEvent(event);
@@ -233,6 +254,7 @@ public class ModCore {
                             return;
                         }
                         ModCore.instance.mods.forEach(mod -> mod.clientEvent(ModEvent.RELOAD));
+                        BuiltinPacks.reload();
                         ClientEvents.fireReload();
                     });
                     BlockRender.onPostColorSetup();

--- a/src/main/java/cam72cam/mod/ModCore.java
+++ b/src/main/java/cam72cam/mod/ModCore.java
@@ -185,7 +185,7 @@ public class ModCore {
                     // Force first and last (and inject mod time) BUG: sounds can still be overridden by resource packs
                     packs.add(1, modPack);
                     packs.add(modPack);
-                    BuiltinPack.loadUMCResource(packs);
+                    BuiltinPack.onConstruct(packs);
 
                     constructed = true;
                 }

--- a/src/main/java/cam72cam/mod/ModCore.java
+++ b/src/main/java/cam72cam/mod/ModCore.java
@@ -10,7 +10,7 @@ import cam72cam.mod.net.Packet;
 import cam72cam.mod.net.PacketDirection;
 import cam72cam.mod.render.BlockRender;
 import cam72cam.mod.render.Light;
-import cam72cam.mod.resource.BuiltinPacks;
+import cam72cam.mod.resource.BuiltinPack;
 import cam72cam.mod.resource.Identifier;
 import cam72cam.mod.text.Command;
 import cam72cam.mod.util.MinecraftFiles;
@@ -177,15 +177,15 @@ public class ModCore {
 
                 if (!constructed) {
                     for (Mod mod : instance.mods) {
-                        BuiltinPacks.loadModResource(mod);
+                        BuiltinPack.loadModResource(mod);
                     }
 
                     List<IResourcePack> packs = Minecraft.getMinecraft().defaultResourcePacks;
-                    IResourcePack modPack = BuiltinPacks.attach(Loader.instance().activeModContainer().getSource());
+                    IResourcePack modPack = BuiltinPack.attach(Loader.instance().activeModContainer().getSource());
                     // Force first and last (and inject mod time) BUG: sounds can still be overridden by resource packs
                     packs.add(1, modPack);
                     packs.add(modPack);
-                    BuiltinPacks.loadWrappedResource(packs);
+                    BuiltinPack.loadWrappedResource(packs);
 
                     constructed = true;
                 }
@@ -254,7 +254,7 @@ public class ModCore {
                             return;
                         }
                         ModCore.instance.mods.forEach(mod -> mod.clientEvent(ModEvent.RELOAD));
-                        BuiltinPacks.reload();
+                        BuiltinPack.reload();
                         ClientEvents.fireReload();
                     });
                     BlockRender.onPostColorSetup();

--- a/src/main/java/cam72cam/mod/ModCore.java
+++ b/src/main/java/cam72cam/mod/ModCore.java
@@ -182,7 +182,9 @@ public class ModCore {
 
                     List<IResourcePack> packs = Minecraft.getMinecraft().defaultResourcePacks;
                     IResourcePack modPack = BuiltinPack.attach(Loader.instance().activeModContainer().getSource());
-                    // Force first and last (and inject mod time) BUG: sounds can still be overridden by resource packs
+                    // Ensure people will get our result first via getResourceStream() and getLastResourceStream()
+                    // (Also injects last modified time access)
+                    // BUG: sounds can still be overridden by resource packs
                     packs.add(1, modPack);
                     packs.add(modPack);
                     BuiltinPack.onConstruct(packs);

--- a/src/main/java/cam72cam/mod/ModCore.java
+++ b/src/main/java/cam72cam/mod/ModCore.java
@@ -10,15 +10,13 @@ import cam72cam.mod.net.Packet;
 import cam72cam.mod.net.PacketDirection;
 import cam72cam.mod.render.BlockRender;
 import cam72cam.mod.render.Light;
+import cam72cam.mod.resource.BuiltinPacks;
 import cam72cam.mod.resource.Identifier;
 import cam72cam.mod.text.Command;
 import cam72cam.mod.util.MinecraftFiles;
 import cam72cam.mod.util.ModCoreCommand;
 import cam72cam.mod.world.ChunkManager;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.FileResourcePack;
-import net.minecraft.client.resources.FolderResourcePack;
-import net.minecraft.client.resources.IResourcePack;
 import net.minecraft.client.resources.SimpleReloadableResourceManager;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod.EventHandler;
@@ -28,8 +26,6 @@ import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartedEvent;
 import net.minecraftforge.fml.relauncher.CoreModManager;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
@@ -37,8 +33,6 @@ import org.apache.logging.log4j.Logger;
 import org.lwjgl.opengl.GL11;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -173,57 +167,10 @@ public class ModCore {
         public void event(ModEvent event, Mod m) {
             if (event == ModEvent.CONSTRUCT) {
                 Config.getMaxTextureSize(); //populate
-
-                List<IResourcePack> packs = Minecraft.getMinecraft().defaultResourcePacks;
-
-                String configDir = Loader.instance().getConfigDir().toString();
-                new File(configDir).mkdirs();
-
-                File folder = new File(configDir + File.separator + m.modID());
-                if (folder.exists()) {
-                    if (folder.isDirectory()) {
-                        File[] files = folder.listFiles((dir, name) -> name.endsWith(".zip"));
-                        for (File file : files) {
-                            packs.add(createPack(file));
-                        }
-
-                        File[] folders = folder.listFiles((dir, name) -> dir.isDirectory());
-                        for (File dir : folders) {
-                            packs.add(createPack(dir));
-                        }
-                    }
-                } else {
-                    folder.mkdirs();
-                }
-
-                IResourcePack modPack = createPack(Loader.instance().activeModContainer().getSource());
-                // Force first and last (and inject mod time) BUG: sounds can still be overridden by resource packs
-                packs.add(1, modPack);
-                packs.add(modPack);
+                BuiltinPacks.loadResource(m);
             }
             super.event(event, m);
             m.clientEvent(event);
-        }
-
-        @SideOnly(Side.CLIENT)
-        private static IResourcePack createPack(File path) {
-            if (path.isDirectory()) {
-                return new FolderResourcePack(path) {
-                    @Override
-                    protected InputStream getInputStreamByName(String name) throws IOException {
-                        InputStream stream = super.getInputStreamByName(name);
-                        File file = this.getFile(name);
-                        return new Identifier.InputStreamMod(stream, file.lastModified());
-                    }
-                };
-            } else {
-                return new FileResourcePack(path) {
-                    @Override
-                    protected InputStream getInputStreamByName(String name) throws IOException {
-                        return new Identifier.InputStreamMod(super.getInputStreamByName(name), resourcePackFile.lastModified());
-                    }
-                };
-            }
         }
 
         @Override

--- a/src/main/java/cam72cam/mod/resource/BuiltinPack.java
+++ b/src/main/java/cam72cam/mod/resource/BuiltinPack.java
@@ -13,9 +13,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * Utilities for wrapping resources across versions.
+ * Utilities for wrapping resources, only available within UMC mods' namespaces.
  * <p>
- * Only available within UMC mods' namespaces.
+ * When handling request, static resources added via <code>put</code> have the highest priority,
+ * then <code>redirect</code>, then<code>conditional</code>.
  * */
 public class BuiltinPack {
     private static final HashMap<Identifier, byte[]> DIRECT_RESOURCES = new HashMap<>();
@@ -57,12 +58,12 @@ public class BuiltinPack {
     /**
      * Registers a resource path redirect.
      * <p>
-     * Any requested identifier whose string form starts with {@code from}
-     * will be remapped to {@code to} (prefix replacement).
+     * Any requested identifier whose string form starts with {@code sourcePrefix}
+     * will be remapped to {@code targetPrefix} (simple replacement).
      * This is mainly intended for compatibility aliases (e.g. cross-version path changes).
      */
-    public static void redirect(Identifier from, Identifier to) {
-        REDIRECTS.put(from, to);
+    public static void redirect(Identifier sourcePrefix, Identifier targetPrefix) {
+        REDIRECTS.put(sourcePrefix, targetPrefix);
     }
 
     /**
@@ -224,10 +225,10 @@ public class BuiltinPack {
         }
     }
 
-    private static Identifier handleRedirect(Identifier src, Identifier from, Identifier to) {
-        //Replace [to] with [from] to implement redirect
-        String suffix = src.toString().substring(to.toString().length());
-        return new Identifier(from.toString() + suffix);
+    private static Identifier handleRedirect(Identifier src, Identifier sourcePrefix, Identifier targetPrefix) {
+        //Replace [to] with [from] to redirect the request back
+        String suffix = src.toString().substring(targetPrefix.toString().length());
+        return new Identifier(sourcePrefix.toString() + suffix);
     }
 
     private static Identifier nameToLocation(String path) {

--- a/src/main/java/cam72cam/mod/resource/BuiltinPack.java
+++ b/src/main/java/cam72cam/mod/resource/BuiltinPack.java
@@ -8,6 +8,8 @@ import net.minecraft.client.resources.data.MetadataSerializer;
 import net.minecraftforge.fml.common.Loader;
 
 import java.io.*;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -16,31 +18,50 @@ import java.util.stream.Collectors;
  * Utilities for wrapping resources across versions
  * */
 public class BuiltinPack {
+    private static final File umcLocation;
+
     private static final HashMap<Identifier, byte[]> DIRECT_RESOURCES = new HashMap<>();
-    private static final HashMap<Identifier, Identifier> REDIRECTS = new HashMap<>();
+    private static final TreeMap<Identifier, Identifier> REDIRECTS =
+            new TreeMap<>((a, b) -> {
+                String aStr = a.toString();
+                String bStr = b.toString();
+                int d = Integer.compare(bStr.length(), aStr.length());
+                return d != 0 ? d : aStr.compareTo(bStr);
+            });
     private static final List<Function<Identifier, byte[]>> GENERATORS = new LinkedList<>();
     private static final HashMap<Identifier, byte[]> CACHED_GENERATOR_RESULTS = new HashMap<>();
+
+    static {
+        try {
+            umcLocation = Paths.get(BuiltinPack.class.getProtectionDomain().getCodeSource().getLocation().toURI())
+                               .toFile();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     /**
      * Directly attach a resource to the game
      */
-    public static void addResource(Identifier resource, byte[] content) {
+    public static void put(Identifier resource, byte[] content) {
         DIRECT_RESOURCES.put(resource, content);
     }
 
     /**
-     * Attach a conditionally generated resource to the game. The result will be cached until next reload.
+     * Attach a conditionally generated resource to the game, return null in the function if conditions not met.
+     * <p>
+     * Once the resource is successfully generated, it will be cached until the next reload.
      */
-    public static void addGenerator(Function<Identifier, byte[]> func) {
+    public static void conditional(Function<Identifier, byte[]> func) {
         GENERATORS.add(func);
     }
 
     /**
      * Add a redirect logic for resources, especially useful when handling cross-version compatibilities
+     * <p>
+     * UMC will match all locations start with <code>from</code>, and replace them with <code>to</code> .
      */
-    public static void addRedirect(Identifier from, Identifier to) {
-        if (!to.canLoad())
-            throw new RuntimeException("Invalid redirect to: " + to);
+    public static void redirect(Identifier from, Identifier to) {
         REDIRECTS.put(from, to);
     }
 
@@ -88,7 +109,7 @@ public class BuiltinPack {
         }
     }
 
-    public static void loadWrappedResource(List<IResourcePack> packs) {
+    public static void loadUMCResource(List<IResourcePack> packs) {
         IResourcePack pack = new InternalPack();
         packs.add(1, pack);
         packs.add(pack);
@@ -100,7 +121,7 @@ public class BuiltinPack {
 
     private static class InternalPack extends AbstractResourcePack {
         public InternalPack() {
-            super(null);
+            super(umcLocation);
         }
 
         @Override
@@ -111,11 +132,12 @@ public class BuiltinPack {
 
             Identifier identifier = nameToLocation(resourcePath);
 
-            //TODO more robust logic
             for (Map.Entry<Identifier, Identifier> entry : REDIRECTS.entrySet()) {
-                if (identifier.toString().startsWith(entry.getKey().toString())) {
-                    Identifier target = new Identifier(identifier.toString().replace(entry.getKey().toString(), entry.getValue().toString()));
-                    return target.getResourceStream();
+                String src = identifier.toString();
+                if (src.startsWith(entry.getKey().toString())) {
+                    //Replace [from] with [to]
+                    String suffix = src.substring(entry.getKey().toString().length());
+                    return new Identifier(entry.getValue().toString() + suffix).getResourceStream();
                 }
             }
 
@@ -123,7 +145,7 @@ public class BuiltinPack {
                 return new ByteArrayInputStream(DIRECT_RESOURCES.get(identifier));
             }
 
-            //It must already have been cached in hasResourceName if exists
+            //It must already have been populated in hasResourceName if exists
             if (CACHED_GENERATOR_RESULTS.containsKey(identifier)) {
                 return new ByteArrayInputStream(CACHED_GENERATOR_RESULTS.get(identifier));
             }

--- a/src/main/java/cam72cam/mod/resource/BuiltinPack.java
+++ b/src/main/java/cam72cam/mod/resource/BuiltinPack.java
@@ -8,8 +8,6 @@ import net.minecraft.client.resources.data.MetadataSerializer;
 import net.minecraftforge.fml.common.Loader;
 
 import java.io.*;
-import java.net.URISyntaxException;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -18,8 +16,6 @@ import java.util.stream.Collectors;
  * Utilities for wrapping resources across versions
  * */
 public class BuiltinPack {
-    private static final File umcLocation;
-
     private static final HashMap<Identifier, byte[]> DIRECT_RESOURCES = new HashMap<>();
     private static final TreeMap<Identifier, Identifier> REDIRECTS =
             new TreeMap<>((a, b) -> {
@@ -30,15 +26,6 @@ public class BuiltinPack {
             });
     private static final List<Function<Identifier, byte[]>> GENERATORS = new LinkedList<>();
     private static final HashMap<Identifier, byte[]> CACHED_GENERATOR_RESULTS = new HashMap<>();
-
-    static {
-        try {
-            umcLocation = Paths.get(BuiltinPack.class.getProtectionDomain().getCodeSource().getLocation().toURI())
-                               .toFile();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     /**
      * Directly attach a resource to the game
@@ -121,7 +108,8 @@ public class BuiltinPack {
 
     private static class InternalPack extends AbstractResourcePack {
         public InternalPack() {
-            super(umcLocation);
+            //We're initializing UMC
+            super(Loader.instance().activeModContainer().getSource());
         }
 
         @Override
@@ -186,9 +174,7 @@ public class BuiltinPack {
 
         @Override
         public Set<String> getResourceDomains() {
-            Set<String> set = ModCore.instance.getLoadedMods().stream().map(ModCore.Mod::modID).collect(Collectors.toSet());
-            set.add("universalmodcore");
-            return set;
+            return ModCore.instance.getLoadedMods().stream().map(ModCore.Mod::modID).collect(Collectors.toSet());
         }
 
         @Override

--- a/src/main/java/cam72cam/mod/resource/BuiltinPack.java
+++ b/src/main/java/cam72cam/mod/resource/BuiltinPack.java
@@ -122,6 +122,7 @@ public class BuiltinPack {
      */
     public static void onConstruct(List<IResourcePack> packs) {
         IResourcePack pack = new InternalPack();
+        //Ensure people will get our result first via getResourceStream() and getLastResourceStream()
         packs.add(1, pack);
         packs.add(pack);
     }

--- a/src/main/java/cam72cam/mod/resource/BuiltinPack.java
+++ b/src/main/java/cam72cam/mod/resource/BuiltinPack.java
@@ -63,6 +63,7 @@ public class BuiltinPack {
      * This is mainly intended for compatibility aliases (e.g. cross-version path changes).
      */
     public static void redirect(Identifier sourcePrefix, Identifier targetPrefix) {
+        //Namespaces will be redirected!
         REDIRECTS.put(sourcePrefix, targetPrefix);
     }
 
@@ -119,7 +120,7 @@ public class BuiltinPack {
     /**
      * Internal
      */
-    public static void loadUMCResource(List<IResourcePack> packs) {
+    public static void onConstruct(List<IResourcePack> packs) {
         IResourcePack pack = new InternalPack();
         packs.add(1, pack);
         packs.add(pack);

--- a/src/main/java/cam72cam/mod/resource/BuiltinPack.java
+++ b/src/main/java/cam72cam/mod/resource/BuiltinPack.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 /**
  * Utilities for wrapping resources across versions
  * */
-public class BuiltinPacks {
+public class BuiltinPack {
     private static final HashMap<Identifier, byte[]> DIRECT_RESOURCES = new HashMap<>();
     private static final HashMap<Identifier, Identifier> REDIRECTS = new HashMap<>();
     private static final List<Function<Identifier, byte[]>> GENERATORS = new LinkedList<>();
@@ -55,12 +55,12 @@ public class BuiltinPacks {
             if (folder.isDirectory()) {
                 File[] files = folder.listFiles(file -> file.getName().endsWith(".zip"));
                 for (File file : files) {
-                    packs.add(BuiltinPacks.attach(file));
+                    packs.add(BuiltinPack.attach(file));
                 }
 
                 File[] folders = folder.listFiles(File::isDirectory);
                 for (File dir : folders) {
-                    packs.add(BuiltinPacks.attach(dir));
+                    packs.add(BuiltinPack.attach(dir));
                 }
             }
         } else {

--- a/src/main/java/cam72cam/mod/resource/BuiltinPack.java
+++ b/src/main/java/cam72cam/mod/resource/BuiltinPack.java
@@ -13,7 +13,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * Utilities for wrapping resources across versions
+ * Utilities for wrapping resources across versions.
+ * <p>
+ * Only available within UMC mods' namespaces.
  * */
 public class BuiltinPack {
     private static final HashMap<Identifier, byte[]> DIRECT_RESOURCES = new HashMap<>();
@@ -29,30 +31,66 @@ public class BuiltinPack {
     private static final HashMap<Identifier, byte[]> CACHED_GENERATOR_RESULTS = new HashMap<>();
 
     /**
-     * Directly attach a resource to the game
+     * Registers a static resource.
+     * <p>
+     * The given bytes are returned as-is whenever this identifier is requested.
+     * If the same identifier is registered again, the latest value wins.
      */
     public static void put(Identifier resource, byte[] content) {
         DIRECT_RESOURCES.put(resource, content);
     }
 
     /**
-     * Attach a conditionally generated resource to the game, return null in the function if conditions not met.
+     * Registers a conditional resource generator.
      * <p>
-     * Once the resource is successfully generated, it will be cached until the next reload.
+     * The function is called with the requested identifier and should return:
+     * <ul>
+     *   <li>resource bytes, if this generator wants to provide it</li>
+     *   <li>{@code null}, if it does not handle this identifier</li>
+     * </ul>
+     * Generated results are cached after the first successful generation, until next resource reload.
      */
     public static void conditional(Function<Identifier, byte[]> func) {
         GENERATORS.add(func);
     }
 
     /**
-     * Add a redirect logic for resources, especially useful when handling cross-version compatibilities
+     * Registers a resource path redirect.
      * <p>
-     * UMC will match all locations start with <code>from</code>, and replace them with <code>to</code> .
+     * Any requested identifier whose string form starts with {@code from}
+     * will be remapped to {@code to} (prefix replacement).
+     * This is mainly intended for compatibility aliases (e.g. cross-version path changes).
      */
     public static void redirect(Identifier from, Identifier to) {
         REDIRECTS.put(from, to);
     }
 
+    /**
+     * Registers a file or folder as an resource pack to the game.
+     */
+    public static IResourcePack attach(File path) {
+        if (path.isDirectory()) {
+            return new FolderResourcePack(path) {
+                @Override
+                protected InputStream getInputStreamByName(String name) throws IOException {
+                    InputStream stream = super.getInputStreamByName(name);
+                    File file = this.getFile(name);
+                    return new Identifier.InputStreamMod(stream, file.lastModified());
+                }
+            };
+        } else {
+            return new FileResourcePack(path) {
+                @Override
+                protected InputStream getInputStreamByName(String name) throws IOException {
+                    return new Identifier.InputStreamMod(super.getInputStreamByName(name), resourcePackFile.lastModified());
+                }
+            };
+        }
+    }
+
+    /**
+     * Internal
+     */
     public static void loadModResource(ModCore.Mod mod) {
         List<IResourcePack> packs = Minecraft.getMinecraft().defaultResourcePacks;
 
@@ -77,36 +115,25 @@ public class BuiltinPack {
         }
     }
 
-    public static IResourcePack attach(File path) {
-        if (path.isDirectory()) {
-            return new FolderResourcePack(path) {
-                @Override
-                protected InputStream getInputStreamByName(String name) throws IOException {
-                    InputStream stream = super.getInputStreamByName(name);
-                    File file = this.getFile(name);
-                    return new Identifier.InputStreamMod(stream, file.lastModified());
-                }
-            };
-        } else {
-            return new FileResourcePack(path) {
-                @Override
-                protected InputStream getInputStreamByName(String name) throws IOException {
-                    return new Identifier.InputStreamMod(super.getInputStreamByName(name), resourcePackFile.lastModified());
-                }
-            };
-        }
-    }
-
+    /**
+     * Internal
+     */
     public static void loadUMCResource(List<IResourcePack> packs) {
         IResourcePack pack = new InternalPack();
         packs.add(1, pack);
         packs.add(pack);
     }
 
+    /**
+     * Internal
+     */
     public static void reload() {
         CACHED_GENERATOR_RESULTS.clear();
     }
 
+    /**
+     * Internal
+     */
     private static class InternalPack extends AbstractResourcePack {
         public InternalPack() {
             //We're initializing UMC

--- a/src/main/java/cam72cam/mod/resource/BuiltinPack.java
+++ b/src/main/java/cam72cam/mod/resource/BuiltinPack.java
@@ -19,6 +19,7 @@ public class BuiltinPack {
     private static final HashMap<Identifier, byte[]> DIRECT_RESOURCES = new HashMap<>();
     private static final TreeMap<Identifier, Identifier> REDIRECTS =
             new TreeMap<>((a, b) -> {
+                //Longer is better
                 String aStr = a.toString();
                 String bStr = b.toString();
                 int d = Integer.compare(bStr.length(), aStr.length());
@@ -118,24 +119,23 @@ public class BuiltinPack {
                 return new ByteArrayInputStream("{}".getBytes());
             }
 
-            Identifier identifier = nameToLocation(resourcePath);
+            Identifier ident = nameToLocation(resourcePath);
 
             for (Map.Entry<Identifier, Identifier> entry : REDIRECTS.entrySet()) {
-                String src = identifier.toString();
-                if (src.startsWith(entry.getKey().toString())) {
-                    //Replace [from] with [to]
-                    String suffix = src.substring(entry.getKey().toString().length());
-                    return new Identifier(entry.getValue().toString() + suffix).getResourceStream();
+                String src = ident.toString();
+                if (src.startsWith(entry.getValue().toString())) {
+                    Identifier redirect = handleRedirect(ident, entry.getKey(), entry.getValue());
+                    return redirect.getResourceStream();
                 }
             }
 
-            if (DIRECT_RESOURCES.containsKey(identifier)) {
-                return new ByteArrayInputStream(DIRECT_RESOURCES.get(identifier));
+            if (DIRECT_RESOURCES.containsKey(ident)) {
+                return new ByteArrayInputStream(DIRECT_RESOURCES.get(ident));
             }
 
             //It must already have been populated in hasResourceName if exists
-            if (CACHED_GENERATOR_RESULTS.containsKey(identifier)) {
-                return new ByteArrayInputStream(CACHED_GENERATOR_RESULTS.get(identifier));
+            if (CACHED_GENERATOR_RESULTS.containsKey(ident)) {
+                return new ByteArrayInputStream(CACHED_GENERATOR_RESULTS.get(ident));
             }
 
             return null;
@@ -143,27 +143,34 @@ public class BuiltinPack {
 
         @Override
         protected boolean hasResourceName(String resourcePath) {
-            Identifier identifier = nameToLocation(resourcePath);
+            if (resourcePath.endsWith("mcmeta") && !"pack.mcmeta".equals(resourcePath)) {
+                //We don't handle resource metadata
+                return false;
+            }
 
-            if (DIRECT_RESOURCES.containsKey(identifier)) {
+            Identifier ident = nameToLocation(resourcePath);
+
+            if (DIRECT_RESOURCES.containsKey(ident)) {
                 return true;
             }
 
             for (Map.Entry<Identifier, Identifier> entry : REDIRECTS.entrySet()) {
-                if (identifier.toString().startsWith(entry.getKey().toString())) {
+                //Check if it's start with any of the [to]s
+                if (ident.toString().startsWith(entry.getValue().toString())
+                        && handleRedirect(ident, entry.getKey(), entry.getValue()).canLoad()) {
                     return true;
                 }
             }
 
-            if (CACHED_GENERATOR_RESULTS.containsKey(identifier)) {
+            if (CACHED_GENERATOR_RESULTS.containsKey(ident)) {
                 return true;
             }
 
             synchronized (GENERATORS) {
                 for (Function<Identifier, byte[]> generator : GENERATORS) {
-                    byte[] stream = generator.apply(identifier);
+                    byte[] stream = generator.apply(ident);
                     if (stream != null) {
-                        CACHED_GENERATOR_RESULTS.put(identifier, stream);
+                        CACHED_GENERATOR_RESULTS.put(ident, stream);
                         return true;
                     }
                 }
@@ -174,7 +181,9 @@ public class BuiltinPack {
 
         @Override
         public Set<String> getResourceDomains() {
-            return ModCore.instance.getLoadedMods().stream().map(ModCore.Mod::modID).collect(Collectors.toSet());
+            Set<String> collect = ModCore.instance.getLoadedMods().stream().map(ModCore.Mod::modID).collect(Collectors.toSet());
+            collect.add("universalmodcore");
+            return collect;
         }
 
         @Override
@@ -188,6 +197,12 @@ public class BuiltinPack {
         }
     }
 
+    private static Identifier handleRedirect(Identifier src, Identifier from, Identifier to) {
+        //Replace [to] with [from] to implement redirect
+        String suffix = src.toString().substring(to.toString().length());
+        return new Identifier(from.toString() + suffix);
+    }
+
     private static Identifier nameToLocation(String path) {
         if(path.startsWith("assets/")) {
             //assets/[domain]/[path] -> domain:path
@@ -196,6 +211,6 @@ public class BuiltinPack {
             return new Identifier(path.substring(0, x), path.substring(x + 1));
         }
         //Not possible to hit below 1.12, except for pack.mcmeta
-        return null;
+        return new Identifier("universalmodcore", "invalid");
     }
 }

--- a/src/main/java/cam72cam/mod/resource/BuiltinPacks.java
+++ b/src/main/java/cam72cam/mod/resource/BuiltinPacks.java
@@ -6,15 +6,22 @@ import net.minecraft.client.resources.FileResourcePack;
 import net.minecraft.client.resources.FolderResourcePack;
 import net.minecraft.client.resources.IResourcePack;
 import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-/** Internal, don't use */
+/**
+ * Internal, don't use
+ * <p>
+ * Keep in mind that some of the methods are side-only
+ * */
 public class BuiltinPacks {
-    public static void loadResource(ModCore.Mod mod) {
+    @SideOnly(Side.CLIENT)
+    public static void loadModResource(ModCore.Mod mod) {
         List<IResourcePack> packs = Minecraft.getMinecraft().defaultResourcePacks;
 
         String configDir = Loader.instance().getConfigDir().toString();
@@ -23,12 +30,12 @@ public class BuiltinPacks {
         File folder = new File(configDir + File.separator + mod.modID());
         if (folder.exists()) {
             if (folder.isDirectory()) {
-                File[] files = folder.listFiles((dir, name) -> name.endsWith(".zip"));
+                File[] files = folder.listFiles(file -> file.getName().endsWith(".zip"));
                 for (File file : files) {
                     packs.add(BuiltinPacks.asResource(file));
                 }
 
-                File[] folders = folder.listFiles((dir, name) -> dir.isDirectory());
+                File[] folders = folder.listFiles(File::isDirectory);
                 for (File dir : folders) {
                     packs.add(BuiltinPacks.asResource(dir));
                 }
@@ -43,6 +50,7 @@ public class BuiltinPacks {
         packs.add(modPack);
     }
 
+    @SideOnly(Side.CLIENT)
     public static IResourcePack asResource(File path) {
         if (path.isDirectory()) {
             return new FolderResourcePack(path) {

--- a/src/main/java/cam72cam/mod/resource/BuiltinPacks.java
+++ b/src/main/java/cam72cam/mod/resource/BuiltinPacks.java
@@ -2,25 +2,48 @@ package cam72cam.mod.resource;
 
 import cam72cam.mod.ModCore;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.FileResourcePack;
-import net.minecraft.client.resources.FolderResourcePack;
-import net.minecraft.client.resources.IResourcePack;
+import net.minecraft.client.resources.*;
+import net.minecraft.client.resources.data.IMetadataSection;
+import net.minecraft.client.resources.data.MetadataSerializer;
 import net.minecraftforge.fml.common.Loader;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
+import java.io.*;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
- * Internal, don't use
- * <p>
- * Keep in mind that some of the methods are side-only
+ * Utilities for wrapping resources across versions
  * */
 public class BuiltinPacks {
-    @SideOnly(Side.CLIENT)
+    private static final HashMap<Identifier, byte[]> DIRECT_RESOURCES = new HashMap<>();
+    private static final HashMap<Identifier, Identifier> REDIRECTS = new HashMap<>();
+    private static final List<Function<Identifier, byte[]>> GENERATORS = new LinkedList<>();
+    private static final HashMap<Identifier, byte[]> CACHED_GENERATOR_RESULTS = new HashMap<>();
+
+    /**
+     * Directly attach a resource to the game
+     */
+    public static void addResource(Identifier resource, byte[] content) {
+        DIRECT_RESOURCES.put(resource, content);
+    }
+
+    /**
+     * Attach a conditionally generated resource to the game. The result will be cached until next reload.
+     */
+    public static void addGenerator(Function<Identifier, byte[]> func) {
+        GENERATORS.add(func);
+    }
+
+    /**
+     * Add a redirect logic for resources, especially useful when handling cross-version compatibilities
+     */
+    public static void addRedirect(Identifier from, Identifier to) {
+        if (!to.canLoad())
+            throw new RuntimeException("Invalid redirect to: " + to);
+        REDIRECTS.put(from, to);
+    }
+
     public static void loadModResource(ModCore.Mod mod) {
         List<IResourcePack> packs = Minecraft.getMinecraft().defaultResourcePacks;
 
@@ -32,26 +55,20 @@ public class BuiltinPacks {
             if (folder.isDirectory()) {
                 File[] files = folder.listFiles(file -> file.getName().endsWith(".zip"));
                 for (File file : files) {
-                    packs.add(BuiltinPacks.asResource(file));
+                    packs.add(BuiltinPacks.attach(file));
                 }
 
                 File[] folders = folder.listFiles(File::isDirectory);
                 for (File dir : folders) {
-                    packs.add(BuiltinPacks.asResource(dir));
+                    packs.add(BuiltinPacks.attach(dir));
                 }
             }
         } else {
             folder.mkdirs();
         }
-
-        IResourcePack modPack = BuiltinPacks.asResource(Loader.instance().activeModContainer().getSource());
-        // Force first and last (and inject mod time) BUG: sounds can still be overridden by resource packs
-        packs.add(1, modPack);
-        packs.add(modPack);
     }
 
-    @SideOnly(Side.CLIENT)
-    public static IResourcePack asResource(File path) {
+    public static IResourcePack attach(File path) {
         if (path.isDirectory()) {
             return new FolderResourcePack(path) {
                 @Override
@@ -69,5 +86,108 @@ public class BuiltinPacks {
                 }
             };
         }
+    }
+
+    public static void loadWrappedResource(List<IResourcePack> packs) {
+        IResourcePack pack = new InternalPack();
+        packs.add(1, pack);
+        packs.add(pack);
+    }
+
+    public static void reload() {
+        CACHED_GENERATOR_RESULTS.clear();
+    }
+
+    private static class InternalPack extends AbstractResourcePack {
+        public InternalPack() {
+            super(null);
+        }
+
+        @Override
+        protected InputStream getInputStreamByName(String resourcePath) throws IOException {
+            if("pack.mcmeta".equals(resourcePath)) {
+                return new ByteArrayInputStream("{}".getBytes());
+            }
+
+            Identifier identifier = nameToLocation(resourcePath);
+
+            //TODO more robust logic
+            for (Map.Entry<Identifier, Identifier> entry : REDIRECTS.entrySet()) {
+                if (identifier.toString().startsWith(entry.getKey().toString())) {
+                    Identifier target = new Identifier(identifier.toString().replace(entry.getKey().toString(), entry.getValue().toString()));
+                    return target.getResourceStream();
+                }
+            }
+
+            if (DIRECT_RESOURCES.containsKey(identifier)) {
+                return new ByteArrayInputStream(DIRECT_RESOURCES.get(identifier));
+            }
+
+            //It must already have been cached in hasResourceName if exists
+            if (CACHED_GENERATOR_RESULTS.containsKey(identifier)) {
+                return new ByteArrayInputStream(CACHED_GENERATOR_RESULTS.get(identifier));
+            }
+
+            return null;
+        }
+
+        @Override
+        protected boolean hasResourceName(String resourcePath) {
+            Identifier identifier = nameToLocation(resourcePath);
+
+            if (DIRECT_RESOURCES.containsKey(identifier)) {
+                return true;
+            }
+
+            for (Map.Entry<Identifier, Identifier> entry : REDIRECTS.entrySet()) {
+                if (identifier.toString().startsWith(entry.getKey().toString())) {
+                    return true;
+                }
+            }
+
+            if (CACHED_GENERATOR_RESULTS.containsKey(identifier)) {
+                return true;
+            }
+
+            synchronized (GENERATORS) {
+                for (Function<Identifier, byte[]> generator : GENERATORS) {
+                    byte[] stream = generator.apply(identifier);
+                    if (stream != null) {
+                        CACHED_GENERATOR_RESULTS.put(identifier, stream);
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        @Override
+        public Set<String> getResourceDomains() {
+            Set<String> set = ModCore.instance.getLoadedMods().stream().map(ModCore.Mod::modID).collect(Collectors.toSet());
+            set.add("universalmodcore");
+            return set;
+        }
+
+        @Override
+        public String getPackName() {
+            return "UMC Generated Resources";
+        }
+
+        @Override
+        public <T extends IMetadataSection> T getPackMetadata(MetadataSerializer metadataSerializer, String metadataSectionName) throws IOException {
+            return super.getPackMetadata(metadataSerializer, metadataSectionName);
+        }
+    }
+
+    private static Identifier nameToLocation(String path) {
+        if(path.startsWith("assets/")) {
+            //assets/[domain]/[path] -> domain:path
+            path = path.substring(7);
+            int x = path.indexOf('/');
+            return new Identifier(path.substring(0, x), path.substring(x + 1));
+        }
+        //Not possible to hit below 1.12, except for pack.mcmeta
+        return null;
     }
 }

--- a/src/main/java/cam72cam/mod/resource/BuiltinPacks.java
+++ b/src/main/java/cam72cam/mod/resource/BuiltinPacks.java
@@ -1,0 +1,65 @@
+package cam72cam.mod.resource;
+
+import cam72cam.mod.ModCore;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.FileResourcePack;
+import net.minecraft.client.resources.FolderResourcePack;
+import net.minecraft.client.resources.IResourcePack;
+import net.minecraftforge.fml.common.Loader;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/** Internal, don't use */
+public class BuiltinPacks {
+    public static void loadResource(ModCore.Mod mod) {
+        List<IResourcePack> packs = Minecraft.getMinecraft().defaultResourcePacks;
+
+        String configDir = Loader.instance().getConfigDir().toString();
+        new File(configDir).mkdirs();
+
+        File folder = new File(configDir + File.separator + mod.modID());
+        if (folder.exists()) {
+            if (folder.isDirectory()) {
+                File[] files = folder.listFiles((dir, name) -> name.endsWith(".zip"));
+                for (File file : files) {
+                    packs.add(BuiltinPacks.asResource(file));
+                }
+
+                File[] folders = folder.listFiles((dir, name) -> dir.isDirectory());
+                for (File dir : folders) {
+                    packs.add(BuiltinPacks.asResource(dir));
+                }
+            }
+        } else {
+            folder.mkdirs();
+        }
+
+        IResourcePack modPack = BuiltinPacks.asResource(Loader.instance().activeModContainer().getSource());
+        // Force first and last (and inject mod time) BUG: sounds can still be overridden by resource packs
+        packs.add(1, modPack);
+        packs.add(modPack);
+    }
+
+    public static IResourcePack asResource(File path) {
+        if (path.isDirectory()) {
+            return new FolderResourcePack(path) {
+                @Override
+                protected InputStream getInputStreamByName(String name) throws IOException {
+                    InputStream stream = super.getInputStreamByName(name);
+                    File file = this.getFile(name);
+                    return new Identifier.InputStreamMod(stream, file.lastModified());
+                }
+            };
+        } else {
+            return new FileResourcePack(path) {
+                @Override
+                protected InputStream getInputStreamByName(String name) throws IOException {
+                    return new Identifier.InputStreamMod(super.getInputStreamByName(name), resourcePackFile.lastModified());
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
As 1.14+ we would have to dynamically generate some resource/data pack entries, it's better to make it a dedicated class

This PR extracted the logic into `BuiltinPack` for a better convention