### PR TITLE
[1.17+ Fix] Add default blockstate to tiles

### DIFF
--- a/src/main/java/cam72cam/mod/block/tile/TileEntity.java
+++ b/src/main/java/cam72cam/mod/block/tile/TileEntity.java
@@ -24,6 +24,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -91,7 +92,7 @@ public class TileEntity extends net.minecraft.world.level.block.entity.BlockEnti
             public BlockPos immutable() {
                 return this; // BAHAHAHAHA
             }
-        }, null);
+        }, Blocks.AIR.defaultBlockState());
         instance = registry.get(id.toString()).get();
         instance.internal = this;
     }


### PR DESCRIPTION
Internal structural PR, waiting for test feedbacks

Able to convert:
- 1.12.2(1.2.2) -> 1.20.1(1.2.3)
- 1.12.2(1.2.3) -> 1.20.1(1.2.3)
- 1.16.5(1.2.3) -> 1.20.1(1.2.3)
- 1.20.1(without this change) -> 1.20.1(1.2.3)
~~Not able to convert:~~
- 1.16.5(1.2.2) -> 1.20.1(1.2.3)