### PR TITLE
[Mainline Chore] Update template files to Java25

### DIFF
--- a/src/main/java/cam72cam/mod/mixin/fix/multi_release/MixinJarDiscoverer.java
+++ b/src/main/java/cam72cam/mod/mixin/fix/multi_release/MixinJarDiscoverer.java
@@ -1,0 +1,24 @@
+package cam72cam.mod.mixin.fix.multi_release;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraftforge.fml.common.discovery.JarDiscoverer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.regex.Matcher;
+import java.util.zip.ZipEntry;
+
+@Mixin(JarDiscoverer.class)
+public class MixinJarDiscoverer {
+    //Skip Java9+ classes in Multi-Release as Forge can't process them
+    @WrapOperation(method = "findClassesASM", at = @At(value = "INVOKE", target = "Ljava/util/regex/Matcher;matches()Z"), remap = false, require = 0)
+    private boolean checkClass(Matcher instance, Operation<Boolean> original, @Local(name = "ze") ZipEntry ze) {
+        if (original.call(instance)) {
+            return !ze.getName().endsWith("module-info.class")
+                   && !ze.getName().startsWith("META-INF/versions/");
+        }
+        return false;
+    }
+}

--- a/src/main/resources/mixins.feat.universalmodcore.json
+++ b/src/main/resources/mixins.feat.universalmodcore.json
@@ -7,6 +7,9 @@
   "minVersion": "0.8.2",
   "compatibilityLevel": "JAVA_8",
   "mixinPriority": 1300,
+  "mixinextras": {
+    "minVersion": "0.5.0"
+  },
   "mixins": [
     "large_entity_collision.MixinVanillaWorld"
   ],

--- a/src/main/resources/mixins.fix.universalmodcore.json
+++ b/src/main/resources/mixins.fix.universalmodcore.json
@@ -6,7 +6,11 @@
   "minVersion": "0.8.2",
   "compatibilityLevel": "JAVA_8",
   "mixinPriority": 1301,
+  "mixinextras": {
+    "minVersion": "0.5.0"
+  },
   "mixins": [
+    "multi_release.MixinJarDiscoverer"
   ],
   "client": [
   ]

--- a/src/main/resources/template/build.gradle
+++ b/src/main/resources/template/build.gradle
@@ -1,45 +1,97 @@
 //BUILDSCRIPT//
-buildscript {
-    repositories {
-        maven { url = "https://maven.minecraftforge.net/" }
-    }
-	dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
-	}
+plugins {
+    id 'java'
+    //A customized fork for better support on Cleanroom
+    id 'xyz.wagyourtail.unimined' version "1.4.18-kappa"
+    id 'com.gradleup.shadow' version "8.3.10"
+    id "maven-publish"
+    id 'xyz.wagyourtail.jvmdowngrader' version '1.3.6'
 }
+configurations {
+    umcShade
+    modImplementation.extendsFrom umcShade
+}
+unimined.useGlobalCache = false
 
 //PLUGINS//
-apply plugin: 'net.minecraftforge.gradle.forge'
 
 //MINECRAFT//
-sourceCompatibility = targetCompatibility = '1.8'
-compileJava {
-    sourceCompatibility = targetCompatibility = '1.8'
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+
+    withSourcesJar()
 }
 
-minecraft {
-    version = "1.12.2-14.23.5.2847"
-    runDir = "run"
-    mappings = "stable_39"
+tasks.withType(JavaCompile).configureEach {
+    options.release = 25
+}
+
+jvmdg {
+    quiet = false
+    multiReleaseOriginal = true
+    //Downgrade to Java8 for MinecraftForge, preserve Java25 for Cleanroom
+    multiReleaseVersions = [JavaVersion.VERSION_1_8, JavaVersion.VERSION_25].toSet()
+}
+
+unimined.minecraft {
+    version "1.12.2"
+
+    mappings {
+        searge()
+        mcp("stable", "39-1.12")
+    }
+
+    cleanroom {
+        loader("0.5.12-alpha")
+    }
+
+    defaultRemapJar = true
 }
 
 //DEPENDENCIES//
 #UMC_REPO#
 
 dependencies {
-    runtime "net.minecrell:terminalconsoleappender:1.3.0"
-    compile #UMC_DEPENDENCY#
+    compileOnly "com.cleanroommc:lwjglx:1.0.0"
+    modImplementation #UMC_DEPENDENCY#
 }
 
 //JAR//
-jar.finalizedBy('reobfJar')
+jar {
+    enabled = false
+}
+
+shadowJar {
+    configurations = [project.configurations.umcShade]
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    mergeServiceFiles()
+    archiveClassifier = 'shadow'
+//    finalizedBy 'reobfShadowJar'
+}
+
+shadeDowngradedApi {
+    inputFile = shadowJar.archiveFile
+}
+
+remapJar {
+    inputFile = tasks.shadeDowngradedApi.archiveFile
+    dependsOn(tasks.named("shadowJar"))
+    archiveClassifier = ''
+}
+
+tasks.named("assemble") {
+    dependsOn(tasks.named("remapJar"))
+}
 
 processResources {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     inputs.property "version", project.version
-    inputs.property "mcversion", project.minecraft.version
+    inputs.property "mcversion", "#MINECRAFT#"
     from(sourceSets.main.resources.srcDirs) {
         include 'mcmod.info'
-        expand 'version':project.version, 'mcversion':project.minecraft.version
+        expand 'version':project.version, 'mcversion':"#MINECRAFT#"
     }
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info'

--- a/src/main/resources/template/build.gradle
+++ b/src/main/resources/template/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'java'
     //A customized fork for better support on Cleanroom
     id 'xyz.wagyourtail.unimined' version "1.4.18-kappa"
-    id 'com.gradleup.shadow' version "8.3.10"
+    id 'com.gradleup.shadow' version "9.4.1"
     id "maven-publish"
     id 'xyz.wagyourtail.jvmdowngrader' version '1.3.6'
 }
@@ -11,7 +11,6 @@ configurations {
     umcShade
     modImplementation.extendsFrom umcShade
 }
-unimined.useGlobalCache = false
 
 //PLUGINS//
 
@@ -30,9 +29,18 @@ tasks.withType(JavaCompile).configureEach {
 
 jvmdg {
     quiet = false
+    downgradeTo = JavaVersion.VERSION_1_8
     multiReleaseOriginal = true
-    //Downgrade to Java8 for MinecraftForge, preserve Java25 for Cleanroom
-    multiReleaseVersions = [JavaVersion.VERSION_1_8, JavaVersion.VERSION_25].toSet()
+    shadeInlining = false
+    dg(configurations.umcShade, false)
+    //MR-JAR uses a Incremental Update-like strategy, so add versions here won't cause too much waste
+    multiReleaseVersions = [
+            JavaVersion.VERSION_1_8,  // 1.16 and below
+            JavaVersion.VERSION_16,   // 1.17
+            JavaVersion.VERSION_17,   // 1.18 - 1.20
+            JavaVersion.VERSION_21,   // 1.21
+            JavaVersion.VERSION_25    // 26.1 and beyond as well as modern 1.7.10/1.12.2
+    ].toSet()
 }
 
 unimined.minecraft {
@@ -68,10 +76,6 @@ shadowJar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     mergeServiceFiles()
     archiveClassifier = 'shadow'
-}
-
-shadeDowngradedApi {
-    inputFile = shadowJar.archiveFile
 }
 
 remapJar {

--- a/src/main/resources/template/build.gradle
+++ b/src/main/resources/template/build.gradle
@@ -68,7 +68,6 @@ shadowJar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     mergeServiceFiles()
     archiveClassifier = 'shadow'
-//    finalizedBy 'reobfShadowJar'
 }
 
 shadeDowngradedApi {

--- a/src/main/resources/template/gradle/wrapper/gradle-wrapper.properties
+++ b/src/main/resources/template/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip

--- a/src/main/resources/template/settings.gradle
+++ b/src/main/resources/template/settings.gradle
@@ -1,0 +1,19 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+        maven {url = "https://plugins.gradle.org/"}
+        maven {url = "https://maven.neoforged.net/releases"}
+        maven {url = "https://maven.minecraftforge.net/"}
+        maven {url = "https://maven.fabricmc.net/"}
+        maven {url = "https://maven.wagyourtail.xyz/releases"}
+        maven {url = "https://maven.wagyourtail.xyz/snapshots"}
+        maven {url = 'https://maven.arcseekers.com/releases'}
+    }
+}
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
+rootProject.name = '#NAME#'


### PR DESCRIPTION
This PR
- Migrate downstream building pipeline to Unimined to gain Java25 support, for better API and grammer candies;
- Introduce Shadow plugin with pre-built `umcShade` configuration;
- Introduce JvmDowngrader for legacy forge support
- Move default 1.12.2 development environment to Cleanroom

Ideally this should be the first step for a better dev experience for UMC users
The logic had been proven to work on a local maven

Downstreams:
https://github.com/TeamOpenIndustry/ImmersiveRailroadingIntegration/pull/21
https://github.com/TeamOpenIndustry/ImmersiveRailroading/pull/1652